### PR TITLE
Refine RAT port selection flow

### DIFF
--- a/tenvy-server/src/lib/utils/rat-port-preferences.ts
+++ b/tenvy-server/src/lib/utils/rat-port-preferences.ts
@@ -1,0 +1,146 @@
+import { browser } from '$app/environment';
+
+const LOCAL_PORT_KEY = 'tenvy.selectedPorts';
+const LOCAL_REMEMBER_KEY = 'tenvy.rememberPorts';
+const SESSION_PORT_KEY = 'tenvy.sessionPorts';
+
+const PORT_MIN = 1;
+const PORT_MAX = 65_535;
+
+type ParseResult = { ok: true; ports: number[] } | { ok: false; error: string };
+
+function normalizePorts(values: number[]) {
+        const unique = Array.from(new Set(values));
+        unique.sort((a, b) => a - b);
+        return unique;
+}
+
+export function formatPortSummary(ports: number[]): string {
+        return ports.length > 0 ? ports.join(', ') : '';
+}
+
+export function parsePortInput(raw: string): ParseResult {
+        const tokens = raw
+                .split(/[\s,]+/)
+                .map((token) => token.trim())
+                .filter(Boolean);
+
+        if (tokens.length === 0) {
+                return { ok: false, error: 'Enter at least one port.' };
+        }
+
+        const values: number[] = [];
+
+        for (const token of tokens) {
+                const port = Number(token);
+
+                if (!Number.isInteger(port) || port < PORT_MIN || port > PORT_MAX) {
+                        return {
+                                ok: false,
+                                error: `Port "${token}" is not valid. Use values between ${PORT_MIN.toLocaleString()} and ${PORT_MAX.toLocaleString()}.`
+                        };
+                }
+
+                values.push(port);
+        }
+
+        return { ok: true, ports: normalizePorts(values) };
+}
+
+function parseStoredPorts(raw: string | null): number[] | null {
+        if (!raw) {
+                return null;
+        }
+
+        try {
+                const parsed = JSON.parse(raw) as unknown;
+                if (!Array.isArray(parsed)) {
+                        return null;
+                }
+
+                const ports = parsed
+                        .map((value) => Number(value))
+                        .filter((value) => Number.isInteger(value) && value >= PORT_MIN && value <= PORT_MAX);
+
+                if (ports.length !== parsed.length || ports.length === 0) {
+                        return null;
+                }
+
+                return normalizePorts(ports);
+        } catch (error) {
+                console.error('Failed to parse stored RAT port preferences', error);
+                return null;
+        }
+}
+
+export type StoredPortPreference = { ports: number[]; remember: boolean };
+
+export function loadStoredPorts(): StoredPortPreference | null {
+        if (!browser) {
+                return null;
+        }
+
+        try {
+                const rememberFlag = window.localStorage.getItem(LOCAL_REMEMBER_KEY);
+
+                if (rememberFlag === 'true') {
+                        const storedPorts = parseStoredPorts(window.localStorage.getItem(LOCAL_PORT_KEY));
+                        if (storedPorts) {
+                                return { ports: storedPorts, remember: true };
+                        }
+
+                        window.localStorage.removeItem(LOCAL_PORT_KEY);
+                        window.localStorage.removeItem(LOCAL_REMEMBER_KEY);
+                }
+
+                const sessionPorts = parseStoredPorts(window.sessionStorage.getItem(SESSION_PORT_KEY));
+                if (sessionPorts) {
+                        return { ports: sessionPorts, remember: false };
+                }
+
+                window.sessionStorage.removeItem(SESSION_PORT_KEY);
+        } catch (error) {
+                console.error('Failed to restore RAT port preferences', error);
+        }
+
+        return null;
+}
+
+export function persistPortSelection(ports: number[], remember: boolean) {
+        if (!browser) {
+                return;
+        }
+
+        try {
+                if (ports.length === 0) {
+                        clearStoredPorts();
+                        return;
+                }
+
+                window.sessionStorage.setItem(SESSION_PORT_KEY, JSON.stringify(ports));
+
+                if (remember) {
+                        window.localStorage.setItem(LOCAL_PORT_KEY, JSON.stringify(ports));
+                        window.localStorage.setItem(LOCAL_REMEMBER_KEY, 'true');
+                } else {
+                        window.localStorage.removeItem(LOCAL_PORT_KEY);
+                        window.localStorage.removeItem(LOCAL_REMEMBER_KEY);
+                }
+        } catch (error) {
+                console.error('Failed to persist RAT port preferences', error);
+        }
+}
+
+export function clearStoredPorts() {
+        if (!browser) {
+                return;
+        }
+
+        try {
+                window.sessionStorage.removeItem(SESSION_PORT_KEY);
+                window.localStorage.removeItem(LOCAL_PORT_KEY);
+                window.localStorage.removeItem(LOCAL_REMEMBER_KEY);
+        } catch (error) {
+                console.error('Failed to clear RAT port preferences', error);
+        }
+}

--- a/tenvy-server/src/routes/(app)/+layout.svelte
+++ b/tenvy-server/src/routes/(app)/+layout.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { cn } from '$lib/utils.js';
-	import {
-		Sidebar as SidebarRoot,
-		SidebarContent,
-		SidebarFooter,
-		SidebarHeader,
+        import { cn } from '$lib/utils.js';
+        import {
+                Sidebar as SidebarRoot,
+                SidebarContent,
+                SidebarFooter,
+                SidebarHeader,
 		SidebarInset,
 		SidebarMenu,
 		SidebarMenuBadge,
@@ -13,29 +13,43 @@
 		SidebarProvider,
 		SidebarRail,
 		SidebarTrigger
-	} from '$lib/components/ui/sidebar/index.js';
-	import { Avatar, AvatarFallback } from '$lib/components/ui/avatar/index.js';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
-	import { Popover, PopoverContent, PopoverTrigger } from '$lib/components/ui/popover/index.js';
-	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
-	import { Separator } from '$lib/components/ui/separator/index.js';
-	import type { IconComponent, NavKey } from '$lib/types/navigation.js';
-	import {
+        } from '$lib/components/ui/sidebar/index.js';
+        import { Avatar, AvatarFallback } from '$lib/components/ui/avatar/index.js';
+        import { Badge } from '$lib/components/ui/badge/index.js';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import { Input } from '$lib/components/ui/input/index.js';
+        import { Label } from '$lib/components/ui/label/index.js';
+        import { Popover, PopoverContent, PopoverTrigger } from '$lib/components/ui/popover/index.js';
+        import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
+        import { Separator } from '$lib/components/ui/separator/index.js';
+        import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+        import * as Dialog from '$lib/components/ui/dialog/index.js';
+        import type { IconComponent, NavKey } from '$lib/types/navigation.js';
+        import type { AuthenticatedUser } from '$lib/server/auth';
+        import {
+                clearStoredPorts,
+                formatPortSummary,
+                loadStoredPorts,
+                parsePortInput,
+                persistPortSelection
+        } from '$lib/utils/rat-port-preferences.js';
+        import {
         Activity,
         Bell,
         LogOut,
         LayoutDashboard,
         Hammer,
+        Plug,
         PlugZap,
         Search,
         Settings,
         User,
         Users,
-		Sun,
-		Moon
-	} from '@lucide/svelte';
-	import { toggleMode } from "mode-watcher";
+                Sun,
+                Moon
+        } from '@lucide/svelte';
+        import { onMount } from 'svelte';
+        import { toggleMode } from "mode-watcher";
 
 	type NavItem = {
 		title: string;
@@ -128,21 +142,113 @@
 		clients: 'Search clients, hosts, IPs...'
 	};
 
-	const defaultSearchPlaceholder = 'Search clients, plugins, activity...';
+        const defaultSearchPlaceholder = 'Search clients, plugins, activity...';
 
-	type LayoutData = { activeNav: NavKey };
+        let selectedPorts = $state<number[]>([]);
+        let rememberPorts = $state(false);
+        let portDialogOpen = $state(false);
+        let portInputValue = $state('');
+        let portDialogRemember = $state(false);
+        let portDialogError = $state<string | null>(null);
+        let hasHydrated = $state(false);
 
-	let { children, data: layoutData } = $props<{ data: LayoutData }>();
+        const portSummary = $derived(() => formatPortSummary(selectedPorts));
 
-	const activeSummary = $derived(() => {
-		const { activeNav } = layoutData as LayoutData;
-		return navSummaries[activeNav];
-	});
+        function openPortDialog() {
+                portInputValue = portSummary();
+                portDialogRemember = rememberPorts;
+                portDialogError = null;
+                portDialogOpen = true;
+        }
 
-	const globalSearchPlaceholder = $derived(() => {
-		const { activeNav } = layoutData as LayoutData;
-		return searchPlaceholders[activeNav] ?? defaultSearchPlaceholder;
-	});
+        function handlePortSubmit() {
+                const trimmed = portInputValue.trim();
+                const result = parsePortInput(trimmed);
+
+                if (!result.ok) {
+                        portDialogError = result.error;
+                        return;
+                }
+
+                selectedPorts = result.ports;
+                rememberPorts = portDialogRemember;
+                portInputValue = formatPortSummary(result.ports);
+                portDialogError = null;
+                portDialogOpen = false;
+
+                persistPortSelection(result.ports, portDialogRemember);
+        }
+
+        function handleClearPortPreferences() {
+                clearStoredPorts();
+                selectedPorts = [];
+                rememberPorts = false;
+                portDialogRemember = false;
+                portInputValue = '';
+                portDialogError = null;
+                portDialogOpen = true;
+        }
+
+        onMount(() => {
+                const stored = loadStoredPorts();
+
+                if (stored) {
+                        selectedPorts = stored.ports;
+                        rememberPorts = stored.remember;
+                        portInputValue = formatPortSummary(stored.ports);
+                        portDialogRemember = stored.remember;
+                } else {
+                        openPortDialog();
+                }
+
+                hasHydrated = true;
+        });
+
+        $effect(() => {
+                if (hasHydrated && !portDialogOpen && selectedPorts.length === 0) {
+                        portDialogOpen = true;
+                }
+        });
+
+        type LayoutData = {
+                activeNav: NavKey;
+                user: AuthenticatedUser;
+        };
+
+        let { children, data: layoutData } = $props<{ data: LayoutData }>();
+
+        const activeSummary = $derived(() => {
+                const { activeNav } = layoutData as LayoutData;
+                return navSummaries[activeNav];
+        });
+
+        const globalSearchPlaceholder = $derived(() => {
+                const { activeNav } = layoutData as LayoutData;
+                return searchPlaceholders[activeNav] ?? defaultSearchPlaceholder;
+        });
+
+        function formatIdentifier(value: string) {
+                const cleaned = value.replace(/[^a-z0-9]/gi, '');
+                const slice = cleaned.slice(0, 2);
+                return slice ? slice.toUpperCase() : 'OP';
+        }
+
+        const operatorInitials = $derived(() => formatIdentifier((layoutData as LayoutData).user.id));
+
+        const operatorLabel = $derived(() => {
+                const id = (layoutData as LayoutData).user.id;
+                return id ? `Operator ${id.slice(0, 6).toUpperCase()}` : 'Operator';
+        });
+
+        const voucherDescriptor = $derived(() => {
+                const { voucherId, voucherActive } = (layoutData as LayoutData).user;
+                const truncated = voucherId.length > 10 ? `${voucherId.slice(0, 10)}…` : voucherId;
+                return `${truncated} · ${voucherActive ? 'Voucher active' : 'Voucher inactive'}`;
+        });
+
+        const voucherStatusBadgeVariant = $derived(() => ((layoutData as LayoutData).user.voucherActive ? 'outline' : 'destructive'));
+
+        const voucherStatusLabel = $derived(() => ((layoutData as LayoutData).user.voucherActive ? 'Voucher active' : 'Voucher inactive'));
 </script>
 
 <SidebarProvider>
@@ -199,12 +305,12 @@
                                     class="flex w-full items-center gap-3 rounded-md bg-sidebar-accent/60 px-3 py-2 text-left transition hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:outline-none"
                                 >
                                     <Avatar class="h-9 w-9">
-                                        <AvatarFallback>OP</AvatarFallback>
+                                        <AvatarFallback>{operatorInitials()}</AvatarFallback>
                                     </Avatar>
                                     <div class="min-w-0 flex-1">
-                                        <p class="truncate text-sm leading-tight font-medium">Operator</p>
+                                        <p class="truncate text-sm leading-tight font-medium">{operatorLabel()}</p>
                                         <p class="truncate text-xs leading-tight text-sidebar-foreground/70">
-                                            admin@tenvy.local
+                                            {voucherDescriptor()}
                                         </p>
                                     </div>
                                     <div class="flex items-center justify-end text-sidebar-foreground/70">
@@ -213,14 +319,22 @@
                                     <span class="sr-only">Open operator menu</span>
                                 </PopoverTrigger>
                                 <PopoverContent align="end" sideOffset={12} class="w-64 space-y-4 p-4">
-                                    <div class="flex items-center gap-3">
-                                        <Avatar class="h-10 w-10">
-                                                <AvatarFallback>OP</AvatarFallback>
-                                        </Avatar>
-                                        <div class="min-w-0">
-                                                <p class="truncate text-sm leading-tight font-medium">Operator</p>
-                                                <p class="truncate text-xs leading-tight text-muted-foreground">admin@tenvy.local</p>
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div class="flex items-center gap-3">
+                                                <Avatar class="h-10 w-10">
+                                                        <AvatarFallback>{operatorInitials()}</AvatarFallback>
+                                                </Avatar>
+                                                <div class="min-w-0">
+                                                        <p class="truncate text-sm leading-tight font-medium">{operatorLabel()}</p>
+                                                        <p class="truncate text-xs leading-tight text-muted-foreground">{voucherDescriptor()}</p>
+                                                </div>
                                         </div>
+                                        <Badge
+                                                variant={voucherStatusBadgeVariant()}
+                                                class="shrink-0 text-[10px] uppercase tracking-wide"
+                                        >
+                                                {voucherStatusLabel()}
+                                        </Badge>
                                     </div>
                                     <Separator />
                                     <div class="grid gap-2">
@@ -272,17 +386,71 @@
 			<SidebarTrigger class="md:hidden" />
 			<Separator orientation="vertical" class="h-6" />
 			<div class="flex flex-1 items-center gap-3">
-				<div class="relative w-full max-w-md">
-					<Search
-						class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-					/>
-					<Input type="search" placeholder={globalSearchPlaceholder()} class="pl-10" />
-				</div>
-				<Button variant="ghost" size="icon">
-					<Bell class="h-4 w-4" />
-					<span class="sr-only">Notifications</span>
-				</Button>
-			</div>
+                        <div class="relative w-full max-w-md">
+                                <Search
+                                        class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                                />
+                                <Input type="search" placeholder={globalSearchPlaceholder()} class="pl-10" />
+                        </div>
+                        <Button
+                                type="button"
+                                variant="outline"
+                                class={cn(
+                                        'hidden sm:inline-flex max-w-xs items-center gap-2 whitespace-nowrap truncate',
+                                        selectedPorts.length === 0 &&
+                                                'border-dashed border-destructive/60 text-destructive hover:text-destructive'
+                                )}
+                                title={
+                                        selectedPorts.length > 0
+                                                ? `RAT listening ports: ${portSummary()}`
+                                                : 'Select RAT listening ports'
+                                }
+                                on:click={() => openPortDialog()}
+                        >
+                                <Plug class="h-4 w-4 shrink-0" />
+                                {#if selectedPorts.length > 0}
+                                        <span class="text-xs uppercase tracking-wide text-muted-foreground">Ports</span>
+                                        <span class="truncate text-sm font-medium">{portSummary()}</span>
+                                        {#if rememberPorts}
+                                                <Badge
+                                                        variant="outline"
+                                                        class="hidden xl:inline-flex text-[10px] uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                        Remembered
+                                                </Badge>
+                                        {/if}
+                                {:else}
+                                        <span class="text-sm font-medium">Select RAT ports</span>
+                                {/if}
+                        </Button>
+                        <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                class={cn(
+                                        'sm:hidden',
+                                        selectedPorts.length === 0 &&
+                                                'border-dashed border-destructive/60 text-destructive hover:text-destructive'
+                                )}
+                                title={
+                                        selectedPorts.length > 0
+                                                ? `RAT listening ports: ${portSummary()}`
+                                                : 'Select RAT listening ports'
+                                }
+                                on:click={() => openPortDialog()}
+                        >
+                                <Plug class="h-4 w-4" />
+                                <span class="sr-only">
+                                        {selectedPorts.length > 0
+                                                ? `Update RAT listening ports (${portSummary()}${rememberPorts ? ', remembered preference' : ''})`
+                                                : 'Configure RAT listening ports'}
+                                </span>
+                        </Button>
+                        <Button variant="ghost" size="icon">
+                                <Bell class="h-4 w-4" />
+                                <span class="sr-only">Notifications</span>
+                        </Button>
+                </div>
 		</header>
 		<div class="flex flex-1 flex-col overflow-hidden">
 			<div class="flex flex-1 flex-col gap-8 overflow-y-auto p-6">
@@ -300,5 +468,69 @@
 				{/key}
 			</div>
 		</div>
-	</SidebarInset>
+        </SidebarInset>
+        <Dialog.Root bind:open={portDialogOpen}>
+                <Dialog.Content class="sm:max-w-lg">
+                        <Dialog.Header>
+                                <Dialog.Title>Configure RAT listening ports</Dialog.Title>
+                                <Dialog.Description>
+                                        Choose the ports the remote access tooling should listen on once you are signed in.
+                                </Dialog.Description>
+                        </Dialog.Header>
+                        <form class="space-y-6" on:submit|preventDefault={handlePortSubmit}>
+                                <div class="space-y-2">
+                                        <Label for="rat-port-input">Listening ports</Label>
+                                        <Input
+                                                id="rat-port-input"
+                                                placeholder="4444, 8080"
+                                                bind:value={portInputValue}
+                                                inputmode="numeric"
+                                                autocomplete="off"
+                                                spellcheck={false}
+                                                aria-invalid={Boolean(portDialogError)}
+                                                aria-describedby={`rat-port-input-hint${portDialogError ? ' rat-port-input-error' : ''}`}
+                                        />
+                                        <p id="rat-port-input-hint" class="text-xs text-muted-foreground">
+                                                Separate multiple ports with commas or spaces. Valid range: 1 to 65,535.
+                                        </p>
+                                </div>
+                                <div class="flex items-start gap-3">
+                                        <Checkbox
+                                                id="remember-rat-ports"
+                                                bind:checked={portDialogRemember}
+                                                aria-describedby="remember-rat-ports-hint"
+                                        />
+                                        <div class="grid gap-1">
+                                                <Label for="remember-rat-ports" class="leading-none">Remember selected ports</Label>
+                                                <p id="remember-rat-ports-hint" class="text-xs text-muted-foreground">
+                                                        Store this preference locally and reuse it for future sessions.
+                                                </p>
+                                        </div>
+                                </div>
+                                {#if portDialogError}
+                                        <p id="rat-port-input-error" class="text-sm text-destructive">{portDialogError}</p>
+                                {/if}
+                                {#if selectedPorts.length > 0}
+                                        <Button
+                                                type="button"
+                                                variant="ghost"
+                                                class="justify-start text-destructive hover:text-destructive focus-visible:ring-destructive/20"
+                                                on:click={handleClearPortPreferences}
+                                        >
+                                                Clear saved ports
+                                        </Button>
+                                {/if}
+                                <Dialog.Footer>
+                                        <Button type="submit">Save ports</Button>
+                                        {#if selectedPorts.length > 0}
+                                                <Dialog.Close child let:props>
+                                                        <Button {...props} type="button" variant="outline">
+                                                                Cancel
+                                                        </Button>
+                                                </Dialog.Close>
+                                        {/if}
+                                </Dialog.Footer>
+                        </form>
+                </Dialog.Content>
+        </Dialog.Root>
 </SidebarProvider>


### PR DESCRIPTION
## Summary
- centralize RAT port parsing, persistence, and clearing helpers for reuse and safer hydration
- enrich the authenticated shell with voucher-based operator metadata and a status badge
- polish the RAT port dialog and controls with accessibility fixes, a remember-state badge, and a clear action

## Testing
- npm run lint *(fails: repository-wide Prettier warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cc045f98832b880f40111761f7d2