### PR TITLE
feat: redesign clients table with filtering

### DIFF
--- a/tenvy-server/src/lib/components/ui/pagination/pagination.svelte
+++ b/tenvy-server/src/lib/components/ui/pagination/pagination.svelte
@@ -1,28 +1,58 @@
 <script lang="ts">
-	import { Pagination as PaginationPrimitive } from 'bits-ui';
+        import { Pagination as PaginationPrimitive } from 'bits-ui';
 
-	import { cn } from '$lib/utils.js';
+        import { cn } from '$lib/utils.js';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		count = 0,
-		perPage = 10,
-		page = $bindable(1),
-		siblingCount = 1,
-		...restProps
-	}: PaginationPrimitive.RootProps = $props();
+        type $$Props = PaginationPrimitive.RootProps;
+
+        type ChildSnippetProps = Parameters<NonNullable<PaginationPrimitive.RootProps['child']>>[0];
+        type PaginationRange = { start: number; end: number };
+        type PaginationItem =
+                | { type: 'page'; value: number; key: string }
+                | { type: 'ellipsis'; key: string };
+
+        interface $$Slots {
+                default: {
+                        pages: PaginationItem[];
+                        range: PaginationRange;
+                        currentPage: number;
+                };
+        }
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                count = 0,
+                perPage = 10,
+                page = $bindable(1),
+                siblingCount = 1,
+                ...restProps
+        }: PaginationPrimitive.RootProps = $props();
 </script>
 
+{#snippet RootChild({ props, pages, range, currentPage }: ChildSnippetProps)}
+        <div
+                {...props}
+                class={cn(
+                        'mx-auto flex w-full justify-center',
+                        className,
+                        props.class as string | undefined
+                )}
+        >
+                {@render children?.({ pages, range, currentPage })}
+        </div>
+{/snippet}
+
 <PaginationPrimitive.Root
-	bind:ref
-	bind:page
-	role="navigation"
-	aria-label="pagination"
-	data-slot="pagination"
-	class={cn('mx-auto flex w-full justify-center', className)}
-	{count}
-	{perPage}
-	{siblingCount}
-	{...restProps}
+        bind:ref
+        bind:page
+        role="navigation"
+        aria-label="pagination"
+        data-slot="pagination"
+        child={RootChild}
+        {count}
+        {perPage}
+        {siblingCount}
+        {...restProps}
 />

--- a/tenvy-server/src/lib/components/ui/table/index.ts
+++ b/tenvy-server/src/lib/components/ui/table/index.ts
@@ -1,0 +1,25 @@
+import Body from './table-body.svelte';
+import Cell from './table-cell.svelte';
+import Footer from './table-footer.svelte';
+import Head from './table-head.svelte';
+import Header from './table-header.svelte';
+import Row from './table-row.svelte';
+import Root from './table.svelte';
+
+export {
+        Body,
+        Cell,
+        Footer,
+        Head,
+        Header,
+        Row,
+        Root,
+        //
+        Body as TableBody,
+        Cell as TableCell,
+        Footer as TableFooter,
+        Head as TableHead,
+        Header as TableHeader,
+        Row as TableRow,
+        Root as Table
+};

--- a/tenvy-server/src/lib/components/ui/table/table-body.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table-body.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+        import type { HTMLAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> & {
+                children?: () => unknown;
+        } = $props();
+</script>
+
+<tbody
+        bind:this={ref}
+        data-slot="table-body"
+        class={cn('[&_tr:last-child]:border-0', className)}
+        {...restProps}
+>
+        {@render children?.()}
+</tbody>

--- a/tenvy-server/src/lib/components/ui/table/table-cell.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table-cell.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+        import type { HTMLTdAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLTdAttributes, HTMLTableCellElement> & {
+                children?: () => unknown;
+        } = $props();
+</script>
+
+<td
+        bind:this={ref}
+        data-slot="table-cell"
+        class={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0 [&:has([role=checkbox])]:pl-4', className)}
+        {...restProps}
+>
+        {@render children?.()}
+</td>

--- a/tenvy-server/src/lib/components/ui/table/table-footer.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table-footer.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+        import type { HTMLAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> & {
+                children?: () => unknown;
+        } = $props();
+</script>
+
+<tfoot
+        bind:this={ref}
+        data-slot="table-footer"
+        class={cn('bg-muted/50 font-medium text-foreground', className)}
+        {...restProps}
+>
+        {@render children?.()}
+</tfoot>

--- a/tenvy-server/src/lib/components/ui/table/table-head.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table-head.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+        import type { HTMLAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement> & {
+                children?: () => unknown;
+        } = $props();
+</script>
+
+<th
+        bind:this={ref}
+        data-slot="table-head"
+        class={cn(
+                'h-12 px-4 text-left align-middle text-xs font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+                className
+        )}
+        {...restProps}
+>
+        {@render children?.()}
+</th>

--- a/tenvy-server/src/lib/components/ui/table/table-header.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table-header.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+        import type { HTMLAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement> & {
+                children?: () => unknown;
+        } = $props();
+</script>
+
+<thead
+        bind:this={ref}
+        data-slot="table-header"
+        class={cn('[&_tr]:border-b', className)}
+        {...restProps}
+>
+        {@render children?.()}
+</thead>

--- a/tenvy-server/src/lib/components/ui/table/table-row.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table-row.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+        import type { HTMLAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement> & {
+                children?: () => unknown;
+        } = $props();
+</script>
+
+<tr
+        bind:this={ref}
+        data-slot="table-row"
+        class={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)}
+        {...restProps}
+>
+        {@render children?.()}
+</tr>

--- a/tenvy-server/src/lib/components/ui/table/table.svelte
+++ b/tenvy-server/src/lib/components/ui/table/table.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+        import type { HTMLTableAttributes } from 'svelte/elements';
+        import { cn, type WithElementRef } from '$lib/utils.js';
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: WithElementRef<HTMLTableAttributes, HTMLTableElement> & { children?: () => unknown } = $props();
+</script>
+
+<table
+        bind:this={ref}
+        data-slot="table"
+        class={cn('w-full caption-bottom text-sm', className)}
+        {...restProps}
+>
+        {@render children?.()}
+</table>


### PR DESCRIPTION
## Summary
- replace the clients card grid with a scrollable table layout and add search, status/tag filters, per-page selection, and manual pagination controls
- expose a reusable shadcn-style table component set and update the pagination wrapper to forward slot props
- surface dialogs for ping and shell commands with stronger null guards and improve the empty state with a deployment button

## Testing
- `bun run check` *(fails: existing svelte-check warnings/errors in client-tool-dialog, client-context-menu, and layout)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eec63a34832bb9dcb1abbfc41698