### PR TITLE
Implement open URL command handling

### DIFF
--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from './config';
 import type { AgentMetrics, AgentStatus } from './agent';
 import type { RemoteDesktopCommandPayload } from './remote-desktop';
 
-export type CommandName = 'ping' | 'shell' | 'remote-desktop' | 'system-info';
+export type CommandName = 'ping' | 'shell' | 'remote-desktop' | 'system-info' | 'open-url';
 
 export interface PingCommandPayload {
         message?: string;
@@ -20,11 +20,17 @@ export interface SystemInfoCommandPayload {
         refresh?: boolean;
 }
 
+export interface OpenUrlCommandPayload {
+        url: string;
+        note?: string;
+}
+
 export type CommandPayload =
         | PingCommandPayload
         | ShellCommandPayload
         | RemoteDesktopCommandPayload
-        | SystemInfoCommandPayload;
+        | SystemInfoCommandPayload
+        | OpenUrlCommandPayload;
 
 export interface CommandInput {
         name: CommandName;


### PR DESCRIPTION
## Summary
- extend shared messaging types to include an `open-url` command payload
- implement Go agent support for validating and launching queued URLs in the default browser
- add client dialog submission logic that validates URLs and queues the new command with user feedback

## Testing
- ⚠️ `(cd tenvy-client && go test ./...)` *(hangs while downloading module dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63a1883e4832ba87b89df4c0d63ce