### PR TITLE
Optimize remote desktop streaming quality

### DIFF
--- a/shared/types/remote-desktop.ts
+++ b/shared/types/remote-desktop.ts
@@ -98,7 +98,7 @@ export interface RemoteDesktopFramePacket {
   width: number;
   height: number;
   keyFrame: boolean;
-  encoding: "png" | "clip";
+  encoding: "png" | "jpeg" | "clip";
   image?: string;
   deltas?: RemoteDesktopDeltaRect[];
   clip?: RemoteDesktopVideoClip;

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/+page.svelte
@@ -342,26 +342,35 @@
 			return;
 		}
 
-		if (frame.keyFrame) {
-			if (!frame.image) {
-				throw new Error('Missing key frame image data');
-			}
-			if (supportsImageBitmap) {
-				try {
-					const bitmap = await decodeBitmap(frame.image, 'image/png');
-					try {
-						context.drawImage(bitmap, 0, 0, frame.width, frame.height);
-					} finally {
-						bitmap.close();
-					}
-					return;
-				} catch (err) {
-					logBitmapFallback(err);
-				}
-			}
-			await drawWithImageElement(context, frame.image, 0, 0, frame.width, frame.height, 'png');
-			return;
-		}
+                if (frame.keyFrame) {
+                        if (!frame.image) {
+                                throw new Error('Missing key frame image data');
+                        }
+                        const mime = frame.encoding === 'jpeg' ? 'image/jpeg' : 'image/png';
+                        if (supportsImageBitmap) {
+                                try {
+                                        const bitmap = await decodeBitmap(frame.image, mime);
+                                        try {
+                                                context.drawImage(bitmap, 0, 0, frame.width, frame.height);
+                                        } finally {
+                                                bitmap.close();
+                                        }
+                                        return;
+                                } catch (err) {
+                                        logBitmapFallback(err);
+                                }
+                        }
+                        await drawWithImageElement(
+                                context,
+                                frame.image,
+                                0,
+                                0,
+                                frame.width,
+                                frame.height,
+                                frame.encoding === 'jpeg' ? 'jpeg' : 'png'
+                        );
+                        return;
+                }
 
 		if (frame.deltas && frame.deltas.length > 0) {
 			if (supportsImageBitmap) {


### PR DESCRIPTION
## Summary
- allow the remote desktop agent to emit JPEG keyframes and deltas with adaptive heuristics and merged tiles to reduce payload size
- update the shared remote desktop frame contract and UI renderer to understand JPEG-encoded frames

## Testing
- ⚠️ `(cd tenvy-client && go test ./...)` *(hangs while fetching native audio dependency, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e6752df530832bbc66be052a8ec4c3